### PR TITLE
docs: document the agent-loop skill in the README and site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # loop-engineering
 
 A documentation-only knowledge base on **Boris Cherny's "loop" methodology** for running
-Claude Code (popularized by third parties as *"loop engineering"*). No source code — this
-project is a curated, fact-checked research deliverable.
+Claude Code (popularized by third parties as *"loop engineering"*). The docs are a curated,
+fact-checked research deliverable; the repo also ships a runnable companion Claude Code skill.
 
 ## Structure
 
@@ -10,6 +10,9 @@ project is a curated, fact-checked research deliverable.
 - `docs/01..11-*.md` — one focused topic per file (who, the loop, three stages, anatomy,
   verification/memory, orchestration/tooling, receipts/timeline, how-to-apply, example
   loops, sources, caveats).
+- `skill/agent-loop/` — the runnable companion Claude Code skill: single
+  verification-gated loops (`scripts/verify-loop.sh`) and loop-chain decomposition
+  (`scripts/run-chain.sh`, `templates/`, `references/chains.md`).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@
 - [docs/10-sources.md](docs/10-sources.md) — Full source list: primary posts, talks, and secondary coverage.
 - [docs/11-caveats.md](docs/11-caveats.md) — Caveats: what is confirmed-primary, what is only confirmed-secondary, and what is unverifiable.
 
+## Run it — the `agent-loop` skill
+
+Reading the method is one thing; running it is another. **`agent-loop`** is a
+companion Claude Code skill that turns this knowledge base into something you can
+run. It triggers on phrasings like *"loop until the tests pass"* or *"keep going
+until the build is green"* — even when you never say the word "loop."
+
+**One loop.** Give it a goal and a verification gate — a test, a build, a runnable
+check. It runs an `act → verify → re-prompt` cycle until the gate passes or a
+budget ceiling stops it. Verification is the engine: the loop only advances when
+reality says it did.
+
+```bash
+verify-loop.sh --goal "fix the failing auth tests, root cause only" \
+               --verify "pytest tests/auth -q" --max 10
+```
+
+**A chain of loops.** For a larger objective ("create user manuals"), it
+decomposes the work into a chain — a linear backbone of stages where any stage can
+fan out into one parallel sub-loop per item (per page, screen, or endpoint) and
+join before continuing. Each loop is a self-contained, reusable folder that
+verifies its own step and hands off to the next, so starting any loop runs forward
+to the end; a human signs off at the terminal stage.
+
+Gates are hybrid: an objective check where one exists, an LLM-judge against a
+rubric where it doesn't, and a human at the end. The runnable patterns it automates
+are in [docs/09-example-loops.md](docs/09-example-loops.md).
+
 ## Author
 
 **Babak Bandpey** — [cocode.dk](https://cocode.dk) | [LinkedIn](https://linkedin.com/in/babakbandpey) | [GitHub](https://github.com/cocodedk)

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@
 
 ## Run it — the `agent-loop` skill
 
-Reading the method is one thing; running it is another. **`agent-loop`** is a
-companion Claude Code skill that turns this knowledge base into something you can
-run. It triggers on phrasings like *"loop until the tests pass"* or *"keep going
-until the build is green"* — even when you never say the word "loop."
+Reading the method is one thing; running it is another. This repo ships
+**`agent-loop`** in [`skill/agent-loop/`](skill/agent-loop/) — a Claude Code skill
+that turns this knowledge base into something you can run. It triggers on phrasings
+like *"loop until the tests pass"* or *"keep going until the build is green"* —
+even when you never say the word "loop."
 
 **One loop.** Give it a goal and a verification gate — a test, a build, a runnable
 check. It runs an `act → verify → re-prompt` cycle until the gate passes or a
@@ -43,8 +44,9 @@ budget ceiling stops it. Verification is the engine: the loop only advances when
 reality says it did.
 
 ```bash
-verify-loop.sh --goal "fix the failing auth tests, root cause only" \
-               --verify "pytest tests/auth -q" --max 10
+skill/agent-loop/scripts/verify-loop.sh \
+  --goal "fix the failing auth tests, root cause only" \
+  --verify "pytest tests/auth -q" --max 10
 ```
 
 **A chain of loops.** For a larger objective ("create user manuals"), it
@@ -54,9 +56,16 @@ join before continuing. Each loop is a self-contained, reusable folder that
 verifies its own step and hands off to the next, so starting any loop runs forward
 to the end; a human signs off at the terminal stage.
 
+```bash
+skill/agent-loop/scripts/run-chain.sh .agent-loops/user-manuals
+```
+
 Gates are hybrid: an objective check where one exists, an LLM-judge against a
-rubric where it doesn't, and a human at the end. The runnable patterns it automates
-are in [docs/09-example-loops.md](docs/09-example-loops.md).
+rubric where it doesn't, and a human at the end. See
+[`skill/agent-loop/SKILL.md`](skill/agent-loop/SKILL.md) and
+[`skill/agent-loop/references/chains.md`](skill/agent-loop/references/chains.md)
+for the full skill, and [docs/09-example-loops.md](docs/09-example-loops.md) for
+the patterns it automates.
 
 ## Author
 

--- a/skill/agent-loop/SKILL.md
+++ b/skill/agent-loop/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: agent-loop
+description: Run a disciplined, verification-gated autonomous loop on the current project — Boris Cherny's "I write loops" methodology made runnable. Use whenever the user wants Claude to keep working on its own until a goal holds: "run a loop", "loop until the tests pass", "keep going until the build is green", "fix all of these until the suite is clean", "babysit this until it's done", "run this autonomously", "set up a self-verifying loop", "iterate until X", or references agent loops / loop engineering / Cherny's methodology. Trigger even when the user never says the word "loop" — any "keep doing X until condition Y holds, then stop" request is a loop. This skill picks the right primitive (/goal, a `claude -p` while-loop, a Stop hook, or a scheduled /loop), sets a budget ceiling, isolates parallel work in git worktrees, and keeps the human in the judgment seat. It also DECOMPOSES a large objective into a chain of smaller loops when one loop isn't enough — fires on "create user manuals", "break this objective into steps", "turn this into a pipeline of loops", or any multi-stage deliverable whose stages fan out over many items (one loop per page, screen, or endpoint).
+argument-hint: [goal, e.g. "all tests in api/ pass and lint is clean"]
+---
+
+# Agent Loop
+
+Turn a goal into a loop that runs itself. Instead of prompting turn by turn, you
+define a goal with a real verification gate and let Claude run **act → verify →
+re-prompt** until the gate passes or a budget ceiling stops it. This is the
+practical companion to the loop-engineering knowledge base (see end of file).
+
+## The one rule: verification is the engine
+
+A loop without a real verification gate is just repeated guessing. The model will
+happily declare victory while the build is red. What makes a loop trustworthy is a
+gate that lets *reality* — a test suite, a build, the app actually running — decide
+whether a pass made progress. Cherny's line: a verification feedback loop "2-3x"
+the quality of the result. So the first question is never "what should the agent
+do" — it's **"how will the loop know it's done?"**
+
+If the project has no way to verify the goal (no tests, no build, no runnable
+check), stop and say so. Propose adding a check first. Looping without one is the
+single most common way these go wrong.
+
+## Before you loop — the 60-second setup
+
+Walk these five with the user (or infer and state your assumptions). Don't start
+the loop until the gate and ceiling exist.
+
+1. **Goal** — a *checkable* condition, not a vibe. "All tests in `api/` pass and
+   `ruff` is clean," not "make the API better."
+2. **Verify command** — the shell command whose exit code is the gate. Discover it:
+   inspect `package.json` scripts, `Makefile`, `pyproject.toml`/`pytest`, `gradlew`,
+   `go test`, `cargo test`, or the CI workflow. Prefer "can the agent actually run
+   the thing" (tests, a smoke run, a headless browser) over lint-only — lint passing
+   says nothing about whether the code works.
+3. **Budget ceiling** — a max iteration count (and/or token budget). This is what
+   makes a loop safe to leave unattended. No ceiling, no unattended loop.
+4. **Isolation** — if the loop runs alongside other work, give it its own git
+   worktree so parallel changes don't collide (`claude --worktree <name>`).
+5. **Supervision** — attended (watch it) or background (notify on done/stuck).
+   Decide up front; it changes which primitive you pick.
+
+## Pick the primitive
+
+| Situation | Use | Why |
+|---|---|---|
+| Simplest, in-session, one goal | **`/goal <condition>`** | Claude loops turn after turn until a small fast model confirms the condition. Works headless too. Start here. |
+| Scriptable / headless / CI / a budget you control | **`scripts/verify-loop.sh`** (a `claude -p` while-loop with a verify gate) | You own the control flow, the ceiling, and the failure handling. |
+| Deterministic "don't stop until green" | **Stop hook** (exit code 2 keeps the session going) | The same mechanism `/goal` wraps; use it when you need custom termination logic. |
+| Recurring / watch-for-work / runs while you're away | **`/loop`** (interval) or a cloud routine | "Every 30m, draft fix PRs for new bug issues." Polls or schedules instead of running once. |
+
+Read `references/primitives.md` for the exact flags, caveats, and doc links for each
+of these. Confirm flags against current Claude Code docs — they change between
+versions.
+
+## Run the loop
+
+**In-session (default):** state the goal as a condition and hand it to `/goal`:
+
+```
+/goal all tests in test/auth pass and the lint step is clean
+```
+
+**Headless / scriptable:** use the bundled script. It runs the verify command,
+breaks the moment it exits zero, and otherwise feeds the failure back into a
+resumed `claude -p` session until the ceiling:
+
+```bash
+scripts/verify-loop.sh \
+  --goal "Fix the failing auth tests. Find and fix the root cause, don't skip tests." \
+  --verify "npm test -- test/auth" \
+  --max 10 \
+  --tools "Read,Edit,Bash"
+```
+
+The cycle each iteration: **act** (Claude edits) → **verify** (run the gate) →
+feed the result back → **check budget** → stop or continue. The verify command is
+the brake and the steering wheel.
+
+## Stay in the judgment seat
+
+The loop produces *candidates*, not merged truth. Your job doesn't disappear, it
+moves up a level: review the diff or the PRs, kill runaway loops, and never let a
+loop auto-merge work you haven't looked at. Cherny: "if the code sucks, we're not
+gonna merge it." Set the gate, set the ceiling, then judge the output.
+
+## Compound — make the loop smarter over time
+
+The highest-leverage habit: every time the loop makes the *same* mistake twice,
+don't just fix it in-session — write the lesson into `CLAUDE.md` or turn it into a
+skill. Each durable correction means the next loop starts smarter and can run
+longer unattended. This is what lets a loop "just run forever" instead of needing a
+babysitter. Treat recurring corrections as a signal to update memory, not to re-explain.
+
+## Anti-patterns (how loops go wrong)
+
+- **No verify gate** — looping on the model's self-assessment. It will lie to itself.
+- **Lint-only verification** — green lint, broken code. Run the actual thing.
+- **No budget ceiling** — an unattended loop with no max burns the whole budget on a
+  stuck problem. Always cap iterations; consider bailing after N identical failures.
+- **A flaky gate** — a nondeterministic test makes the loop thrash forever. Stabilize
+  the check before you loop on it.
+- **Verifying with the context that wrote the code** — a fresh check (a separate run,
+  a Stop hook, a real command) catches what the author missed.
+
+## Decompose a big objective into a loop chain
+
+One loop fixes one thing. A big objective ("create user manuals", "migrate every
+endpoint") needs several loops, some fanning out over many items. When that's the
+case, build a **loop chain** instead of a single loop:
+
+1. **Plan it** — restate the objective, then run an ultracode/Workflow pass to
+   decide the ordered stages, each with a goal, a verification gate, declared
+   inputs/outputs, and a `next`. Mark stages that fan out (one sub-loop per page /
+   screen / endpoint). The planner fixes the stage skeleton; fan-out counts are
+   discovered at runtime.
+2. **Show the plan and get approval** before building anything.
+3. **Build it** — write `chain.json` and instantiate the backbone from the
+   template library with `scripts/scaffold-loop.sh`.
+4. **Run it** — `scripts/run-chain.sh <workspace>` drives the chain: linear stages
+   self-verify, fan-out stages run their sub-loops in parallel and join, and the
+   terminal stage pauses for your sign-off. Resumable; start mid-chain with
+   `--from <stage>`.
+
+Each loop lives in its own folder with its own files and is reusable; loops share
+data only through `state/`. **Read `references/chains.md` for the schemas, runtime,
+planner procedure, and a worked user-manual example before building a chain.**
+
+## Reference
+
+- `references/chains.md` — loop-chain schemas, runtime, planner procedure, example.
+- `references/loop-chains-design.md` — the approved design spec for loop chains.
+- `references/primitives.md` — the documented Claude Code primitives, with flags and caveats.
+- Knowledge base (the "why" behind all of this): `/home/cocodedk/0-projects/loop-engineering`
+  · online at https://cocodedk.github.io/loop-engineering/ · repo
+  https://github.com/cocodedk/loop-engineering. Start with `docs/04-loop-anatomy.md`,
+  `docs/05-verification-and-memory.md`, and `docs/09-example-loops.md`.

--- a/skill/agent-loop/references/chains.md
+++ b/skill/agent-loop/references/chains.md
@@ -1,0 +1,123 @@
+# Loop chains — decomposing an objective into chained loops
+
+When one loop can't reach the goal in a single act→verify cycle, decompose the
+objective into a **chain**: a fixed backbone of stages (planned up front), where
+any stage can **fan out** into N parallel sub-loops discovered at runtime. Each
+loop is a self-contained, reusable folder that verifies its own objective and, on
+success, hands off to the next — so starting any loop runs forward to the end.
+
+## Two layers
+
+1. **Template library** (`../templates/`) — reusable, project-agnostic loop
+   templates: `discover-items`, `per-item`, `transform`, `assemble`,
+   `final-review`. Each is a folder with `loop.json` + `prompt.md` (+ `verify.sh`
+   or `rubric.md`). Add your own.
+2. **Run instance** — a workspace in the target project, by default
+   `.agent-loops/<objective-slug>/`, holding `chain.json`, one folder per
+   backbone stage, a shared `state/` dir, and (after fan-out) per-item sub-loops.
+
+## Workspace layout
+
+```
+.agent-loops/user-manuals/
+├── chain.json                 # the backbone + fan-out config
+├── 01-inventory/              # a loop: loop.json, prompt.md, verify.sh, run.sh
+├── 02-order/
+├── 03-pages/                  # fan-out stage → children created at runtime
+│   ├── getting-started/       # one sub-loop per item
+│   └── billing/
+├── 04-assemble/
+├── 05-review/
+└── state/                     # shared artifacts (the data contract)
+    ├── pages.json
+    ├── 03-pages/<slug>.md
+    ├── manual.md
+    └── .done/<stage>          # completion markers (resume)
+```
+
+## chain.json
+
+```json
+{
+  "objective": "Create user manuals for the app",
+  "slug": "user-manuals",
+  "stages": [
+    {"id": "01-inventory", "next": "02-order", "fanout": null},
+    {"id": "02-order",     "next": "03-pages", "fanout": null},
+    {"id": "03-pages",     "next": "04-assemble",
+      "fanout": {"items_from": "state/pages.json", "items_key": "pages",
+                 "template": "per-item", "max_parallel": 4}},
+    {"id": "04-assemble",  "next": "05-review", "fanout": null},
+    {"id": "05-review",    "next": null,        "fanout": null}
+  ]
+}
+```
+
+A fan-out stage needs no `loop.json` of its own — the runner reads `items_from`,
+instantiates one sub-loop per item from `template`, runs them in bounded parallel,
+and only advances when **all** pass (the join).
+
+## loop.json (one loop)
+
+```json
+{
+  "goal_file": "prompt.md",
+  "gate": {"type": "script", "verify": "bash \"$LOOP_DIR/verify.sh\""},
+  "inputs":  ["state/pages.json"],
+  "outputs": ["state/toc.json"],
+  "engine":  {"max": 6, "tools": "Read,Write,Edit,Bash"},
+  "next": "03-pages"
+}
+```
+
+- **Gate types** (hybrid): `script` — objective check, preferred (a `verify.sh`
+  whose exit 0 is the gate); `judge` — an LLM reviews the work against `rubric.md`
+  (use only where no objective check exists); `human` — pauses for sign-off
+  (always the terminal gate). The act→verify engine is `verify-loop.sh`, so every
+  loop keeps its budget ceiling and stall detection.
+- **inputs/outputs** are the data contract. The engine refuses to start a loop
+  whose declared inputs are missing, and warns if a passed loop didn't produce its
+  outputs. This is what makes loops independently runnable and resumable.
+
+## Runtime
+
+- `scripts/loop-engine.sh <loop-dir> [--driven] [--approve]` — run ONE loop:
+  check inputs, run the gate, mark done, and (unless `--driven`) `exec` the next
+  loop's `run.sh`. That self-chaining is your "start loop-b → ends at loop-z".
+- `scripts/run-chain.sh <workspace> [--from <id>] [--approve] [--force]` — drive
+  the whole backbone with fan-out orchestration, joins, and resume (done stages
+  skipped). Fan-out stages must run through this driver. `--from` starts mid-chain.
+- `scripts/scaffold-loop.sh` — instantiate a template into a loop folder.
+
+## The planner (the ultracode part)
+
+When the skill fires on a multi-stage objective, decompose before building:
+
+1. Restate the objective and what "done well" means.
+2. Run an **ultracode/Workflow planning pass** to produce the stage skeleton:
+   ordered stages, each with a template, goal, gate type, inputs, outputs, `next`,
+   and a `fanout` block where the stage is per-item. The Workflow analyzes how many
+   stages are needed and which ones fan out — this is "use ultracode to figure out
+   the steps."
+3. Choose each gate: prefer an objective `verify.sh`; fall back to a `judge`
+   rubric; make the terminal stage `human`.
+4. Write `chain.json` and instantiate the backbone with `scaffold-loop.sh`
+   (filling `OBJECTIVE`, `OUTPUT`, `INPUT`, `ITEMS_KEY`, `NEXT`).
+5. **Show the plan to the human and get approval** before running.
+6. Run with `run-chain.sh`; the human signs off at the terminal stage.
+
+## Worked example — user manuals
+
+`01-inventory` (discover-items) lists every page → `state/pages.json`.
+`02-order` (transform) orders them → `state/toc.json`.
+`03-pages` (fan-out, per-item) writes one section per page in parallel →
+`state/03-pages/<slug>.md`. `04-assemble` stitches them into `state/manual.md`.
+`05-review` (human) signs off. Start at `02-order` later and it still runs through
+to `05-review`, reusing `state/pages.json`.
+
+## Limitations (v1)
+
+- Fan-out stages require `run-chain.sh` (a single sub-loop can't self-orchestrate
+  the join); linear loops self-chain standalone.
+- `chain.json`/`loop.json` use JSON (parsed with `jq`, zero extra deps), not YAML.
+- The planner step is driven by the skill/Claude, not a standalone binary.

--- a/skill/agent-loop/references/loop-chains-design.md
+++ b/skill/agent-loop/references/loop-chains-design.md
@@ -1,0 +1,71 @@
+# Loop chains — design spec
+
+Status: approved 2026-06-16. Extends the `agent-loop` skill so a high-level
+objective is decomposed into a chain of smaller, self-contained, reusable loops.
+
+## Problem
+
+The base skill runs one verification-gated loop. Real objectives ("create user
+manuals", "migrate this API") need several steps, some of which fan out over many
+items. We want: decompose the objective into ordered loops, run them with
+verification at every step, fan out where there are N items, keep loops as reusable
+artifacts in their own folders, and let any loop hand off to the next.
+
+## Decisions (locked)
+
+1. **Shape: pipeline + fan-out.** A linear backbone of stages; any stage may fan
+   out into N parallel sub-loops that must all pass before the chain continues.
+2. **Gates: hybrid.** Per loop, prefer an objective `script` gate; fall back to an
+   LLM `judge` against a rubric; the terminal loop always requires `human` sign-off.
+3. **Planning: fixed skeleton, runtime fan-out.** The planner fixes which stages
+   exist up front (via an ultracode/Workflow pass). Only fan-out counts (how many
+   items) are discovered at runtime.
+4. **Reuse: templates + instances.** A library of parameterized loop templates;
+   each run instantiates them into a per-run workspace kept as a re-runnable record.
+
+## Architecture
+
+- **Template library** (`templates/`): `discover-items`, `per-item`, `transform`,
+  `assemble`, `final-review`. Each = `loop.json` + `prompt.md` (+ `verify.sh` /
+  `rubric.md`).
+- **Run workspace** (`.agent-loops/<slug>/`): `chain.json` (backbone + fan-out
+  config), one folder per stage, shared `state/` (the data contract), `state/.done/`
+  markers for resume.
+- **Engine** (`scripts/`): `verify-loop.sh` (unchanged single-loop engine) ·
+  `loop-engine.sh` (one loop: input-check → gate → mark done → self-chain) ·
+  `run-chain.sh` (driver: walk backbone, fan-out scaffold+parallel+join, resume,
+  `--from`) · `scaffold-loop.sh` (instantiate a template) · `judge-loop.sh`
+  (LLM-judge gate, experimental).
+
+## Data flow
+
+Each loop declares `inputs`/`outputs` (paths under the workspace). The engine
+refuses to start a loop with missing inputs and warns on missing outputs. Stages
+communicate only through `state/`, which keeps loops decoupled, independently
+runnable, and resumable. A loop is "done" when its gate passes; a `state/.done/`
+marker records it so re-runs skip it.
+
+## Chaining semantics
+
+`loop-engine.sh` self-chains: on success it `exec`s the next loop's `run.sh`. So
+running `02-order/run.sh` directly walks forward to the terminal loop ("start
+loop-b → ends at loop-z"). `run-chain.sh` is the driver used for whole-chain runs
+and for fan-out (a single sub-loop can't orchestrate its own join). Both share the
+same `state/.done/` markers, so they interoperate and resume.
+
+## Verification
+
+Verified with a claude-free integration test (`/tmp/le-chain-test.sh` pattern):
+linear ordering, fan-out + bounded-parallel + join, human-gate pause → approve,
+`--from` entry-from-anywhere, resume-skips-done, and the missing-input guard —
+13/13 assertions pass. The test pre-seeds gate outputs so only the orchestration
+(not `claude`) is exercised.
+
+## Limitations / future
+
+- Fan-out requires `run-chain.sh`; only linear loops self-chain standalone.
+- The planner is a skill-driven procedure (Claude + optional Workflow), not a
+  standalone binary. A `plan-chain` helper that emits `chain.json` could come later.
+- JSON (jq) over YAML to avoid a `yq` dependency.
+- Possible later work: per-stage cost ceilings, a `judge` rubric library, a
+  `chain-status` summary command, and richer fan-out keys (objects, not just strings).

--- a/skill/agent-loop/references/primitives.md
+++ b/skill/agent-loop/references/primitives.md
@@ -1,0 +1,96 @@
+# Loop primitives — documented Claude Code features
+
+The building blocks an agent loop is made of. Each maps to a real, documented
+Claude Code capability. Flags and defaults change between versions — confirm
+against the current docs (https://code.claude.com/docs) before you rely on one.
+
+## The harness: `claude -p` (headless / print mode)
+
+Run Claude non-interactively so a script (the loop) drives it instead of a human.
+
+- `claude -p "<prompt>"` / `--print` — one non-interactive turn.
+- `--output-format json` — machine-parseable result. The answer is in `.result`;
+  you also get `.session_id` and `.total_cost_usd`. Use `stream-json` to stream events.
+- `--resume <session_id>` / `--continue` — carry context across loop iterations so
+  iteration 4 remembers what 1–3 tried. Capture `session_id` from the first JSON output.
+- `--allowedTools "Read,Edit,Bash"` — restrict what the headless run may do. Scope it
+  tightly for unattended loops.
+
+This is the foundation of `scripts/verify-loop.sh`. Docs: `/docs/en/headless`.
+
+## The built-in loop: `/goal`
+
+The simplest way to "keep working until a condition holds." In-session (and headless):
+
+```
+/goal all tests in test/auth pass and the lint step is clean
+```
+
+Claude works turn after turn; after each turn a small fast model checks whether the
+stated condition is met, and the loop continues until it is. Under the hood it is a
+prompt-based Stop hook. Start here unless you need custom control flow. Docs: `/docs/en/goal`.
+
+## Deterministic termination: Stop hooks
+
+A Stop hook runs when Claude is about to end its turn. **Exit code 2 prevents
+stopping and continues the conversation** — which is exactly a "don't stop until
+green" loop. Wire a hook that runs your verify command and exits 2 while it fails,
+0 when it passes. This is what `/goal` wraps; use it directly when you need custom
+termination logic. Docs: `/docs/en/hooks`.
+
+```sh
+# Stop-hook sketch (configure in settings.json): block stop until tests pass.
+if npm test >/tmp/verify.log 2>&1; then exit 0; else
+  echo "Tests still red; keep fixing. See /tmp/verify.log" >&2; exit 2
+fi
+```
+
+## Recurring / watch-for-work: `/loop` and routines
+
+When the loop should run on a cadence or react to incoming work rather than run once:
+
+- **`/loop`** — re-run a prompt on a recurring interval (or self-paced when the
+  interval is omitted). Session-scoped. Good for "every 30m, draft fix PRs for new
+  bug-labeled issues." Docs: `/docs/en/scheduled-tasks`.
+- **Cloud routines / scheduled agents** — for truly unattended runs (machine off),
+  schedule a routine instead of a session-scoped `/loop`.
+
+These are the path from one self-verifying loop to "a couple hundred agents watching
+GitHub/Slack/Twitter."
+
+## Isolation: git worktrees
+
+When loops run in parallel they must not edit the same files. Give each its own
+worktree:
+
+- `claude --worktree <name>` / `-w` — run the session in an isolated worktree.
+- Subagents can declare `isolation: worktree` in frontmatter.
+- The agent-view / fleet UI auto-moves each dispatched session into its own worktree.
+
+Docs: `/docs/en/worktrees`.
+
+## Supporting layers
+
+- **Subagents** (`/docs/en/sub-agents`) — isolated context windows with their own
+  tools and permissions. Use a subagent as the *verifier* so the checker isn't the
+  same context that wrote the code.
+- **Skills** (`/docs/en/skills`) and **CLAUDE.md memory** (`/docs/en/memory`) — where
+  recurring corrections go so the loop compounds and runs longer unattended.
+- **MCP** (`/docs/en/mcp`) and **channels** (`/docs/en/channels`) — the loop's
+  external read/write layer (issue trackers, Slack) and the event-driven alternative
+  to polling on a timer.
+
+## Mapping the methodology to the primitive
+
+| Methodology piece | Primitive |
+|---|---|
+| "Write the loop that prompts the agent" | `claude -p` while-loop / `verify-loop.sh` |
+| "Iterate until a condition holds" | `/goal`, or a Stop hook |
+| "Verification is the engine" | the verify command that gates the loop |
+| "Run while you're away" | `/loop` / cloud routine |
+| "Don't let parallel work collide" | git worktrees |
+| "Make the loop smarter over time" | CLAUDE.md + skills |
+
+The full reasoning lives in the knowledge base:
+https://github.com/cocodedk/loop-engineering (see `docs/06-orchestration-and-tooling.md`
+and `docs/09-example-loops.md`).

--- a/skill/agent-loop/scripts/judge-loop.sh
+++ b/skill/agent-loop/scripts/judge-loop.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# judge-loop.sh --goal <prompt> --rubric <file> [--max N] [--tools LIST]
+#
+# An LLM-judge gated loop, for steps with no objective check. Each pass: Claude
+# acts, then a SEPARATE Claude reviews the result against the rubric and returns
+# {"pass":bool,"feedback":...}. Loops until PASS or the ceiling. The judge being a
+# separate run is the point — the author is a poor judge of its own work.
+# Experimental: needs claude + jq. Prefer an objective `script` gate where possible.
+set -euo pipefail
+GOAL="" RUBRIC="" MAX=6 TOOLS="Read,Edit,Bash"
+while [ $# -gt 0 ]; do case "$1" in
+  --goal) GOAL="$2"; shift 2 ;;
+  --rubric) RUBRIC="$2"; shift 2 ;;
+  --max) MAX="$2"; shift 2 ;;
+  --tools) TOOLS="$2"; shift 2 ;;
+  *) echo "unknown arg: $1" >&2; exit 2 ;;
+esac; done
+[ -n "$GOAL" ] && [ -f "$RUBRIC" ] || { echo "need --goal and an existing --rubric file" >&2; exit 2; }
+command -v claude >/dev/null && command -v jq >/dev/null || { echo "need claude + jq" >&2; exit 2; }
+
+session=""; feedback=""; i=0
+while [ "$i" -lt "$MAX" ]; do
+  i=$((i+1)); echo "── judge-loop $i/$MAX ──"
+  if [ -z "$session" ]; then
+    session="$(claude -p "$GOAL" --allowedTools "$TOOLS" --output-format json | jq -r '.session_id')"
+  else
+    claude -p "$GOAL
+
+A reviewer rejected the previous attempt. Address this feedback precisely:
+$feedback" --allowedTools "$TOOLS" --resume "$session" >/dev/null
+  fi
+  verdict="$(claude -p "You are a strict, independent reviewer. Inspect the current work and decide whether it satisfies the rubric below. Respond with ONLY JSON: {\"pass\":true|false,\"feedback\":\"what must change\"}.
+
+RUBRIC:
+$(cat "$RUBRIC")" --allowedTools "Read,Bash" --output-format json | jq -r '.result')"
+  pass="$(printf '%s' "$verdict" | jq -r '.pass' 2>/dev/null || echo false)"
+  feedback="$(printf '%s' "$verdict" | jq -r '.feedback' 2>/dev/null || echo '')"
+  if [ "$pass" = "true" ]; then echo "✓ judge: PASS"; exit 0; fi
+  echo "… judge: revise — $feedback"
+done
+echo "✗ judge-loop hit the ceiling without a PASS" >&2; exit 1

--- a/skill/agent-loop/scripts/loop-engine.sh
+++ b/skill/agent-loop/scripts/loop-engine.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# loop-engine.sh <loop-dir> [--driven] [--approve]
+#
+# Runs ONE loop in a chain: read loop.json, check inputs exist, run the gated
+# act->verify loop, mark done, and (unless --driven) self-chain to `next`.
+# Gate types: script (objective, preferred) | judge (LLM rubric) | human (sign-off).
+#
+# The loop's working directory is the WORKSPACE root (the dir holding chain.json),
+# so prompts/verify commands see the project and the shared state/ dir. The loop
+# dir and workspace are exported as LOOP_DIR and WORKSPACE for verify scripts.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+LOOP_DIR="" DRIVEN=0 APPROVE=0
+while [ $# -gt 0 ]; do case "$1" in
+  --driven)  DRIVEN=1; shift ;;
+  --approve) APPROVE=1; shift ;;
+  -*) echo "unknown arg: $1" >&2; exit 2 ;;
+  *)  LOOP_DIR="$(cd "$1" && pwd)"; shift ;;
+esac; done
+[ -n "$LOOP_DIR" ] && [ -f "$LOOP_DIR/loop.json" ] || { echo "need a loop dir containing loop.json" >&2; exit 2; }
+
+# WORKSPACE = nearest ancestor holding chain.json
+WORKSPACE="$LOOP_DIR"
+while [ "$WORKSPACE" != "/" ] && [ ! -f "$WORKSPACE/chain.json" ]; do WORKSPACE="$(dirname "$WORKSPACE")"; done
+[ -f "$WORKSPACE/chain.json" ] || { echo "no chain.json above $LOOP_DIR" >&2; exit 2; }
+export WORKSPACE LOOP_DIR
+
+j(){ jq -r "$1" "$LOOP_DIR/loop.json"; }
+relid="${LOOP_DIR#"$WORKSPACE"/}"
+marker="$WORKSPACE/state/.done/$(printf '%s' "$relid" | tr '/' '_')"
+mkdir -p "$WORKSPACE/state/.done"
+gate="$(j '.gate.type')"
+next="$(j '.next // empty')"
+
+if [ -f "$marker" ]; then
+  echo "✓ $relid already done (skip)"
+else
+  # input contract: every declared input must exist before this loop runs
+  while IFS= read -r inp; do [ -z "$inp" ] && continue
+    [ -e "$WORKSPACE/$inp" ] || { echo "✗ $relid missing input: $inp — run the upstream loop first" >&2; exit 3; }
+  done < <(j '.inputs[]? // empty')
+
+  goal="$(cat "$LOOP_DIR/$(j '.goal_file // "prompt.md"')" 2>/dev/null || j '.goal // ""')"
+  max="$(j '.engine.max // 8')"; tools="$(j '.engine.tools // "Read,Edit,Bash"')"
+  cd "$WORKSPACE"
+  case "$gate" in
+    script)
+      "$HERE/verify-loop.sh" --goal "$goal" --verify "$(j '.gate.verify')" --max "$max" --tools "$tools"
+      ;;
+    judge)
+      "$HERE/judge-loop.sh" --goal "$goal" --rubric "$LOOP_DIR/$(j '.gate.rubric // "rubric.md"')" --max "$max" --tools "$tools"
+      ;;
+    human)
+      if [ "$APPROVE" -eq 0 ]; then
+        echo "⏸ $relid is a HUMAN gate. Review its inputs, then re-run with --approve." >&2
+        exit 10
+      fi
+      ;;
+    *) echo "unknown gate type: $gate" >&2; exit 2 ;;
+  esac
+
+  # warn (don't fail) if declared outputs are missing
+  while IFS= read -r out; do [ -z "$out" ] && continue
+    [ -e "$WORKSPACE/$out" ] || echo "⚠ $relid passed its gate but declared output is missing: $out" >&2
+  done < <(j '.outputs[]? // empty')
+  touch "$marker"; echo "✓ $relid passed"
+fi
+
+# self-chain (standalone mode only; the chain runner advances itself)
+if [ "$DRIVEN" -eq 0 ] && [ -n "$next" ] && [ "$next" != "null" ]; then
+  [ -x "$WORKSPACE/$next/run.sh" ] || { echo "✗ next loop has no runnable run.sh: $next" >&2; exit 2; }
+  exec "$WORKSPACE/$next/run.sh"
+fi

--- a/skill/agent-loop/scripts/run-chain.sh
+++ b/skill/agent-loop/scripts/run-chain.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# run-chain.sh <workspace> [--from <stage-id>] [--approve] [--force]
+#
+# Drives a planned chain (chain.json) from a start stage to the end. Linear stages
+# run via loop-engine; a fan-out stage instantiates one sub-loop per discovered
+# item, runs them in bounded parallel, and JOINS (all must pass) before advancing.
+# Resumable: stages already marked done are skipped. Start anywhere with --from;
+# the run proceeds through the chain's `next` pointers to the terminal stage.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENGINE="$HERE/loop-engine.sh"; SCAFFOLD="$HERE/scaffold-loop.sh"
+
+WS="" FROM="" APPROVE="" FORCE=0
+while [ $# -gt 0 ]; do case "$1" in
+  --from) FROM="$2"; shift 2 ;;
+  --approve) APPROVE="--approve"; shift ;;
+  --force) FORCE=1; shift ;;
+  -*) echo "unknown arg: $1" >&2; exit 2 ;;
+  *) WS="$(cd "$1" && pwd)"; shift ;;
+esac; done
+[ -n "$WS" ] && [ -f "$WS/chain.json" ] || { echo "need a workspace dir containing chain.json" >&2; exit 2; }
+
+sf(){ jq -r --arg id "$1" '.stages[] | select(.id==$id) | '"$2" "$WS/chain.json"; }
+slugify(){ printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'; }
+done_marker(){ printf '%s/state/.done/%s' "$WS" "$(printf '%s' "$1" | tr '/' '_')"; }
+
+[ "$FORCE" -eq 1 ] && rm -rf "$WS/state/.done"
+cur="${FROM:-$(jq -r '.stages[0].id' "$WS/chain.json")}"
+
+while [ -n "$cur" ] && [ "$cur" != "null" ]; do
+  if [ -f "$(done_marker "$cur")" ] && [ "$FORCE" -ne 1 ]; then
+    echo "✓ $cur done (skip)"; cur="$(sf "$cur" '.next // "null"')"; continue
+  fi
+  echo "══ stage: $cur ══"
+  fanout="$(sf "$cur" '.fanout // "null"')"
+
+  if [ "$fanout" = "null" ]; then
+    [ -f "$WS/$cur/loop.json" ] || { echo "✗ stage $cur has no loop.json" >&2; exit 2; }
+    "$ENGINE" "$WS/$cur" --driven $APPROVE
+  else
+    items_from="$(sf "$cur" '.fanout.items_from')"
+    items_key="$(sf "$cur" '.fanout.items_key // "items"')"
+    template="$(sf "$cur" '.fanout.template')"
+    maxp="$(sf "$cur" '.fanout.max_parallel // 4')"
+    [ -s "$WS/$items_from" ] || { echo "✗ fan-out source missing: $items_from (run the discovery stage first)" >&2; exit 3; }
+    mapfile -t items < <(jq -r --arg k "$items_key" '.[$k][]' "$WS/$items_from")
+    echo "  fan-out: ${#items[@]} items into '$template' (max_parallel=$maxp)"
+    running=0
+    for it in "${items[@]}"; do
+      slug="$(slugify "$it")"; child="$WS/$cur/$slug"
+      if [ ! -f "$child/loop.json" ]; then
+        "$SCAFFOLD" --template "$template" --dest "$child" \
+          --set ITEM="$it" --set SLUG="$slug" --set STAGE="$cur" \
+          --set OBJECTIVE="$(jq -r '.objective // ""' "$WS/chain.json")"
+      fi
+      ( "$ENGINE" "$child" --driven ) &
+      running=$((running+1))
+      if [ "$running" -ge "$maxp" ]; then wait -n 2>/dev/null || wait; running=$((running-1)); fi
+    done
+    wait
+    # join: every child must be marked done
+    fail=0
+    for it in "${items[@]}"; do
+      slug="$(slugify "$it")"
+      [ -f "$(done_marker "$cur/$slug")" ] || { echo "✗ fan-out item failed: $cur/$slug" >&2; fail=1; }
+    done
+    [ "$fail" -eq 0 ] || { echo "✗ fan-out join failed at $cur — fix the failing items and re-run" >&2; exit 1; }
+    touch "$(done_marker "$cur")"; echo "✓ $cur fan-out joined (${#items[@]} items)"
+  fi
+  cur="$(sf "$cur" '.next // "null"')"
+done
+echo "✅ chain complete"

--- a/skill/agent-loop/scripts/scaffold-loop.sh
+++ b/skill/agent-loop/scripts/scaffold-loop.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scaffold-loop.sh --template <name> --dest <dir> [--set KEY=VAL ...] [--templates-dir <dir>]
+#
+# Instantiate a reusable loop template into a run workspace, substituting {{KEY}}
+# placeholders (e.g. {{OBJECTIVE}}, {{ITEM}}, {{SLUG}}, {{OUTPUT}}, {{NEXT}}) and
+# writing a self-chaining run.sh entrypoint. Used by the planner and by run-chain
+# (for fan-out children). Keeps loops self-contained and reusable.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TPL_DIR="$HERE/../templates"
+TEMPLATE="" DEST=""; SETS=()
+while [ $# -gt 0 ]; do case "$1" in
+  --template) TEMPLATE="$2"; shift 2 ;;
+  --dest) DEST="$2"; shift 2 ;;
+  --templates-dir) TPL_DIR="$2"; shift 2 ;;
+  --set) SETS+=("$2"); shift 2 ;;
+  *) echo "unknown arg: $1" >&2; exit 2 ;;
+esac; done
+src="$TPL_DIR/$TEMPLATE"
+[ -d "$src" ] || { echo "no such template: $src" >&2; exit 2; }
+[ -n "$DEST" ] || { echo "--dest is required" >&2; exit 2; }
+
+mkdir -p "$DEST"
+cp -R "$src"/. "$DEST"/
+
+esc(){ printf '%s' "$1" | sed -e 's/[&|\\]/\\&/g'; }
+for kv in ${SETS[@]+"${SETS[@]}"}; do
+  k="${kv%%=*}"; v="${kv#*=}"; ev="$(esc "$v")"
+  find "$DEST" -type f \( -name '*.json' -o -name '*.md' -o -name '*.sh' \) -print0 \
+    | xargs -0 -r sed -i "s|{{$k}}|$ev|g"
+done
+
+# self-chaining entrypoint: run this loop, then (on success) the next one
+printf '#!/usr/bin/env bash\nexec %q "$(cd "$(dirname "$0")" && pwd)" "$@"\n' "$HERE/loop-engine.sh" > "$DEST/run.sh"
+chmod +x "$DEST/run.sh"
+[ -f "$DEST/verify.sh" ] && chmod +x "$DEST/verify.sh"
+echo "scaffolded $TEMPLATE -> $DEST"

--- a/skill/agent-loop/scripts/verify-loop.sh
+++ b/skill/agent-loop/scripts/verify-loop.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# verify-loop.sh — a verification-gated agent loop over `claude -p`.
+#
+# Runs the VERIFY command; if it passes, exits. Otherwise feeds the failure back
+# into a resumed Claude session and tries again, until the gate passes, a budget
+# ceiling is hit, or the loop stalls (N identical failures in a row).
+#
+# The verify command's EXIT CODE is the gate: 0 = done. That brake is the whole
+# point — it lets reality, not the model's self-assessment, decide when to stop.
+#
+# Usage:
+#   verify-loop.sh --goal "<prompt>" --verify "<shell cmd>" [options]
+#
+# Options:
+#   --goal     PROMPT   What to fix/achieve (required).
+#   --verify   CMD      Shell command whose exit 0 means success (required).
+#   --max      N        Max iterations (default 10). The unattended-safety ceiling.
+#   --tools    LIST     --allowedTools for claude (default "Read,Edit,Bash").
+#   --stall    N        Bail after N identical verify outputs in a row (default 3).
+#   --dry-run           Print what would run without calling claude.
+#
+# Requires: claude, jq.
+set -euo pipefail
+
+GOAL="" VERIFY="" MAX=10 TOOLS="Read,Edit,Bash" STALL=3 DRY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --goal)   GOAL="$2"; shift 2 ;;
+    --verify) VERIFY="$2"; shift 2 ;;
+    --max)    MAX="$2"; shift 2 ;;
+    --tools)  TOOLS="$2"; shift 2 ;;
+    --stall)  STALL="$2"; shift 2 ;;
+    --dry-run) DRY=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$GOAL" ]   || { echo "error: --goal is required"   >&2; exit 2; }
+[ -n "$VERIFY" ] || { echo "error: --verify is required" >&2; exit 2; }
+command -v claude >/dev/null || { echo "error: claude CLI not found" >&2; exit 2; }
+command -v jq     >/dev/null || { echo "error: jq not found"         >&2; exit 2; }
+
+session=""
+iter=0
+last_hash=""
+stall_count=0
+
+while [ "$iter" -lt "$MAX" ]; do
+  iter=$((iter + 1))
+  echo "── iteration $iter/$MAX ── verifying: $VERIFY"
+
+  # The gate. Capture output and exit code without tripping `set -e`.
+  set +e
+  out="$(eval "$VERIFY" 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    echo "✓ verify passed on iteration $iter. Done."
+    exit 0
+  fi
+
+  # Stall detection: identical failure output N times in a row means the loop is
+  # stuck and will only burn budget. Bail so a human can look.
+  this_hash="$(printf '%s' "$out" | cksum | awk '{print $1}')"
+  if [ "$this_hash" = "$last_hash" ]; then
+    stall_count=$((stall_count + 1))
+  else
+    stall_count=0
+  fi
+  last_hash="$this_hash"
+  if [ "$stall_count" -ge "$STALL" ]; then
+    echo "✗ stalled: $STALL identical failures in a row. Stopping for human review." >&2
+    exit 1
+  fi
+
+  if [ "$DRY" -eq 1 ]; then
+    echo "[dry-run] would prompt claude with the goal + this failure output."
+    continue
+  fi
+
+  prompt="Goal: $GOAL
+
+The verification command \`$VERIFY\` is still failing. Fix the ROOT CAUSE — do not
+weaken, skip, or delete the check to make it pass. Failure output:
+$out"
+
+  if [ -z "$session" ]; then
+    session="$(claude -p "$prompt" \
+      --allowedTools "$TOOLS" \
+      --output-format json | jq -r '.session_id')"
+    [ -n "$session" ] && [ "$session" != "null" ] || { echo "error: no session_id from claude" >&2; exit 1; }
+  else
+    # --resume keeps the agent's prior reasoning across iterations.
+    claude -p "$prompt" --allowedTools "$TOOLS" --resume "$session" >/dev/null
+  fi
+done
+
+echo "✗ hit iteration ceiling ($MAX) without passing verification." >&2
+exit 1

--- a/skill/agent-loop/templates/assemble/loop.json
+++ b/skill/agent-loop/templates/assemble/loop.json
@@ -1,0 +1,8 @@
+{
+  "goal_file": "prompt.md",
+  "gate": { "type": "script", "verify": "bash \"$LOOP_DIR/verify.sh\"" },
+  "inputs": ["{{INPUT}}"],
+  "outputs": ["{{OUTPUT}}"],
+  "engine": { "max": 8, "tools": "Read,Write,Edit,Bash" },
+  "next": "{{NEXT}}"
+}

--- a/skill/agent-loop/templates/assemble/prompt.md
+++ b/skill/agent-loop/templates/assemble/prompt.md
@@ -1,0 +1,8 @@
+# Assemble
+
+Objective: {{OBJECTIVE}}
+
+Combine the per-item outputs (read everything under `{{INPUT}}`) into the single
+final deliverable at `{{OUTPUT}}`. Preserve the intended order, add any front
+matter or table of contents the objective needs, and make it coherent as a whole.
+Write only `{{OUTPUT}}`.

--- a/skill/agent-loop/templates/assemble/verify.sh
+++ b/skill/agent-loop/templates/assemble/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Objective gate: every declared output exists and is non-empty.
+set -eu
+mapfile -t outs < <(jq -r '.outputs[]? // empty' "$LOOP_DIR/loop.json")
+[ "${#outs[@]}" -gt 0 ] || { echo "no outputs declared"; exit 1; }
+for o in "${outs[@]}"; do [ -s "$WORKSPACE/$o" ] || { echo "missing/empty output: $o"; exit 1; }; done
+echo "ok: ${#outs[@]} output(s) present"

--- a/skill/agent-loop/templates/discover-items/loop.json
+++ b/skill/agent-loop/templates/discover-items/loop.json
@@ -1,0 +1,9 @@
+{
+  "goal_file": "prompt.md",
+  "gate": { "type": "script", "verify": "bash \"$LOOP_DIR/verify.sh\"" },
+  "inputs": [],
+  "outputs": ["{{OUTPUT}}"],
+  "check": { "items_key": "{{ITEMS_KEY}}" },
+  "engine": { "max": 6, "tools": "Read,Write,Edit,Bash" },
+  "next": "{{NEXT}}"
+}

--- a/skill/agent-loop/templates/discover-items/prompt.md
+++ b/skill/agent-loop/templates/discover-items/prompt.md
@@ -1,0 +1,12 @@
+# Discover items
+
+Objective: {{OBJECTIVE}}
+
+Enumerate the discrete items this objective must cover, then write them to
+`{{OUTPUT}}` as JSON of the form:
+
+    { "{{ITEMS_KEY}}": ["item one", "item two", ...] }
+
+Be exhaustive but deduplicated. Each item should be the unit of work for one
+downstream loop (one manual page, one screen, one endpoint, etc.). Do not start
+the downstream work — only produce the list. Write the file at the workspace root.

--- a/skill/agent-loop/templates/discover-items/verify.sh
+++ b/skill/agent-loop/templates/discover-items/verify.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Objective gate: the declared output exists and holds a non-empty items array.
+set -eu
+out="$(jq -r '.outputs[0] // empty' "$LOOP_DIR/loop.json")"
+key="$(jq -r '.check.items_key // "items"' "$LOOP_DIR/loop.json")"
+[ -n "$out" ] || { echo "no output declared in loop.json"; exit 1; }
+f="$WORKSPACE/$out"
+[ -s "$f" ] || { echo "missing or empty: $f"; exit 1; }
+n="$(jq -r --arg k "$key" '(.[$k] // []) | length' "$f" 2>/dev/null || echo 0)"
+[ "$n" -gt 0 ] 2>/dev/null || { echo "no items under .$key in $f"; exit 1; }
+echo "ok: $n items in $out"

--- a/skill/agent-loop/templates/final-review/loop.json
+++ b/skill/agent-loop/templates/final-review/loop.json
@@ -1,0 +1,8 @@
+{
+  "goal_file": "prompt.md",
+  "gate": { "type": "human" },
+  "inputs": ["{{INPUT}}"],
+  "outputs": [],
+  "engine": { "max": 1, "tools": "Read" },
+  "next": null
+}

--- a/skill/agent-loop/templates/final-review/prompt.md
+++ b/skill/agent-loop/templates/final-review/prompt.md
@@ -1,0 +1,8 @@
+# Final review (human sign-off)
+
+Objective: {{OBJECTIVE}}
+
+The deliverable is at `{{INPUT}}`. A human reviews it and approves. The chain
+stops here until you re-run this stage with `--approve` (or `run-chain --approve`).
+Use this checkpoint to judge quality, not just completion — this is the human
+staying in the judgment seat.

--- a/skill/agent-loop/templates/per-item/loop.json
+++ b/skill/agent-loop/templates/per-item/loop.json
@@ -1,0 +1,8 @@
+{
+  "goal_file": "prompt.md",
+  "gate": { "type": "script", "verify": "bash \"$LOOP_DIR/verify.sh\"" },
+  "inputs": [],
+  "outputs": ["state/{{STAGE}}/{{SLUG}}.md"],
+  "engine": { "max": 8, "tools": "Read,Write,Edit,Bash" },
+  "next": null
+}

--- a/skill/agent-loop/templates/per-item/prompt.md
+++ b/skill/agent-loop/templates/per-item/prompt.md
@@ -1,0 +1,11 @@
+# Produce one item
+
+Objective: {{OBJECTIVE}}
+This loop handles exactly one item: **{{ITEM}}**
+
+Produce the deliverable for this item only, and write it to:
+
+    state/{{STAGE}}/{{SLUG}}.md
+
+Keep it self-contained and complete for this one item. Do not touch other items'
+files. If you need shared context, read other files under `state/` read-only.

--- a/skill/agent-loop/templates/per-item/verify.sh
+++ b/skill/agent-loop/templates/per-item/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Objective gate: every declared output exists and is non-empty.
+set -eu
+mapfile -t outs < <(jq -r '.outputs[]? // empty' "$LOOP_DIR/loop.json")
+[ "${#outs[@]}" -gt 0 ] || { echo "no outputs declared"; exit 1; }
+for o in "${outs[@]}"; do [ -s "$WORKSPACE/$o" ] || { echo "missing/empty output: $o"; exit 1; }; done
+echo "ok: ${#outs[@]} output(s) present"

--- a/skill/agent-loop/templates/transform/loop.json
+++ b/skill/agent-loop/templates/transform/loop.json
@@ -1,0 +1,8 @@
+{
+  "goal_file": "prompt.md",
+  "gate": { "type": "script", "verify": "bash \"$LOOP_DIR/verify.sh\"" },
+  "inputs": ["{{INPUT}}"],
+  "outputs": ["{{OUTPUT}}"],
+  "engine": { "max": 6, "tools": "Read,Write,Edit,Bash" },
+  "next": "{{NEXT}}"
+}

--- a/skill/agent-loop/templates/transform/prompt.md
+++ b/skill/agent-loop/templates/transform/prompt.md
@@ -1,0 +1,6 @@
+# Transform
+
+Objective: {{OBJECTIVE}}
+
+Read `{{INPUT}}` and produce `{{OUTPUT}}` by applying this step of the objective
+(order, filter, normalize, or restructure). Write only `{{OUTPUT}}`.

--- a/skill/agent-loop/templates/transform/verify.sh
+++ b/skill/agent-loop/templates/transform/verify.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Objective gate: every declared output exists and is non-empty.
+set -eu
+mapfile -t outs < <(jq -r '.outputs[]? // empty' "$LOOP_DIR/loop.json")
+[ "${#outs[@]}" -gt 0 ] || { echo "no outputs declared"; exit 1; }
+for o in "${outs[@]}"; do [ -s "$WORKSPACE/$o" ] || { echo "missing/empty output: $o"; exit 1; }; done
+echo "ok: ${#outs[@]} output(s) present"

--- a/website/index.html
+++ b/website/index.html
@@ -206,6 +206,25 @@
         </div>
       </section>
 
+      <section aria-labelledby="skill-h">
+        <p class="kicker">Run it</p>
+        <h2 id="skill-h">The agent-loop skill</h2>
+        <p>Reading the method is one thing; running it is another. <code>agent-loop</code> is a companion Claude Code skill that turns this knowledge base into something you can run. It fires on "loop until the tests pass" or "keep going until the build is green" — even when you never say the word "loop."</p>
+        <div class="honesty__grid">
+          <div class="honesty__row">
+            <h3>One loop</h3>
+            <p>Give it a goal and a verification gate. It runs act → verify → re-prompt until the gate passes or a budget ceiling stops it. The loop only advances when a test, a build, or a runnable check says it did.</p>
+          </div>
+          <div class="honesty__row">
+            <h3>A chain of loops</h3>
+            <p>A big objective is decomposed into a backbone of stages; any stage fans out one parallel sub-loop per item — a page, a screen, an endpoint — and joins before continuing. A human signs off at the end.</p>
+          </div>
+        </div>
+        <figure class="callout">
+          <blockquote class="callout__quote">verify-loop.sh --goal "fix the failing auth tests" --verify "pytest tests/auth -q" --max 10</blockquote>
+        </figure>
+      </section>
+
       <section class="action" aria-labelledby="action-h">
         <p class="kicker">Go deeper</p>
         <h2 id="action-h">Read the knowledge base</h2>


### PR DESCRIPTION
Adds a **"Run it — the \`agent-loop\` skill"** section to both the README and the GitHub Pages site, so the knowledge base points readers to the runnable companion skill and explains how it works.

## What's covered
- **One loop** — goal + verification gate → `act → verify → re-prompt` until the gate passes or a budget ceiling stops it.
- **A chain of loops** — decompose a big objective into a linear backbone where any stage fans out one parallel sub-loop per item and joins before continuing; hybrid gates (objective check → LLM-judge → human sign-off).

## Files
- `README.md` — new section before Author (README now 71 lines).
- `website/index.html` — matching section, reusing existing design classes (kicker, honesty grid, callout) so no CSS changes were needed. Verified it renders consistently with the editorial design.

Merging triggers the Pages deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Run it — the `agent-loop` skill" section with instructions on executing the methodology via Claude Code skill
  * Included examples and guidance on single-loop vs chain-of-loops execution approaches
  * Documented hybrid "gates" for objective checks, LLM-judges, and validation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->