### PR TITLE
feat(agent-loop): v0.2.0 — red-first gate, signature stall, isolation/escalation flags

### DIFF
--- a/skill/agent-loop/CHANGELOG.md
+++ b/skill/agent-loop/CHANGELOG.md
@@ -11,6 +11,31 @@ tweak that changes nothing about the interface.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-17
+
+Hardening of the single-loop gate, learned from running a real flaky-suite loop.
+
+### Added
+- `verify-loop.sh` **red-first guard**: runs the gate before any change and refuses to
+  start if it is already green — a gate that passes for the wrong reason (typo'd path,
+  doesn't exercise the bug) otherwise "succeeds" having done nothing. `--allow-green-start`
+  opts out (exit code 3 = green-before-change).
+- `verify-loop.sh` flags: `--reset-every N` (drop the session for fresh eyes when an
+  approach entrenches), `--escalate-model M` (last-ditch stronger model on the round
+  before a stall bail), `--worktree PATH` (run the whole loop on a throwaway branch),
+  `--log DIR` (write each iteration's verify output + git diff for an audit trail).
+- SKILL.md: gate-*validity* guidance (prove red-first; use behavioral/live-data gates
+  for correctness/security goals, not coverage); a flaky-gate diagnosis playbook
+  (measure the rate, separate infra-flake from real bug, state-guard/bisect); and the
+  `judge-loop.sh` LLM-judge gate + `loop-engine.sh` chain runner are now surfaced in the
+  primitive table / chain steps.
+
+### Changed
+- `verify-loop.sh` stall detection compares a **normalized failure signature** (failure
+  lines with paths/clock-times/durations/line-numbers/hex stripped, deduped) instead of
+  an exact-output hash — so it catches "no progress" even when the failure looks
+  cosmetically different each round (the case that previously burned the whole budget).
+
 ## [0.1.0] — 2026-06-16
 
 Initial release. The runnable companion to the loop-engineering knowledge base.

--- a/skill/agent-loop/SKILL.md
+++ b/skill/agent-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-loop
-version: 0.1.0
+version: 0.2.0
 description: Run a disciplined, verification-gated autonomous loop on the current project — Boris Cherny's "I write loops" methodology made runnable. Use whenever the user wants Claude to keep working on its own until a goal holds: "run a loop", "loop until the tests pass", "keep going until the build is green", "fix all of these until the suite is clean", "babysit this until it's done", "run this autonomously", "set up a self-verifying loop", "iterate until X", or references agent loops / loop engineering / Cherny's methodology. Trigger even when the user never says the word "loop" — any "keep doing X until condition Y holds, then stop" request is a loop. This skill picks the right primitive (/goal, a `claude -p` while-loop, a Stop hook, or a scheduled /loop), sets a budget ceiling, isolates parallel work in git worktrees, and keeps the human in the judgment seat. It also DECOMPOSES a large objective into a chain of smaller loops when one loop isn't enough — fires on "create user manuals", "break this objective into steps", "turn this into a pipeline of loops", or any multi-stage deliverable whose stages fan out over many items (one loop per page, screen, or endpoint).
 argument-hint: [goal, e.g. "all tests in api/ pass and lint is clean"]
 ---
@@ -24,6 +24,16 @@ do" — it's **"how will the loop know it's done?"**
 If the project has no way to verify the goal (no tests, no build, no runnable
 check), stop and say so. Propose adding a check first. Looping without one is the
 single most common way these go wrong.
+
+**A gate proves only what it asserts — so validate the gate, don't just run it.**
+Two traps hide here: a gate green *for the wrong reason* (a typo'd test path, a check
+that never exercises the bug — 100% coverage with mocks has shipped real auth bugs
+past review), and a gate too shallow to catch a behavioral break. Two habits close
+both: **prove it red-first** — run the gate on the *unfixed* code and confirm it fails
+*for the right reason* before looping (`verify-loop.sh` does this by default and
+refuses a green start unless `--allow-green-start`); and for correctness- or
+security-critical goals make the gate **behavioral / live-data** (drive the real
+endpoint, assert the real contract), not coverage.
 
 ## Before you loop — the 60-second setup
 
@@ -52,6 +62,7 @@ the loop until the gate and ceiling exist.
 | Scriptable / headless / CI / a budget you control | **`scripts/verify-loop.sh`** (a `claude -p` while-loop with a verify gate) | You own the control flow, the ceiling, and the failure handling. |
 | Deterministic "don't stop until green" | **Stop hook** (exit code 2 keeps the session going) | The same mechanism `/goal` wraps; use it when you need custom termination logic. |
 | Recurring / watch-for-work / runs while you're away | **`/loop`** (interval) or a cloud routine | "Every 30m, draft fix PRs for new bug issues." Polls or schedules instead of running once. |
+| A step with NO objective check (prose, design, "is this good enough?") | **`scripts/judge-loop.sh`** (LLM-judge gate) | A *separate* Claude scores the result against a rubric and returns pass/fail — independent verification when no shell command can decide. |
 
 Read `references/primitives.md` for the exact flags, caveats, and doc links for each
 of these. Confirm flags against current Claude Code docs — they change between
@@ -81,6 +92,14 @@ The cycle each iteration: **act** (Claude edits) → **verify** (run the gate) �
 feed the result back → **check budget** → stop or continue. The verify command is
 the brake and the steering wheel.
 
+Safety flags worth knowing (`--help` lists all): `--stall N` bails after N no-progress
+rounds (compared by *normalized signature*, not exact output, so it still catches a
+loop that fails differently each round); `--reset-every N` drops the session for fresh
+eyes when an approach entrenches; `--escalate-model M` makes a last-ditch stronger-model
+attempt before a stall bail; `--worktree PATH` runs the loop on a throwaway branch;
+`--log DIR` writes each iteration's verify output + diff as an audit trail;
+`--allow-green-start` skips the red-first guard.
+
 ## Stay in the judgment seat
 
 The loop produces *candidates*, not merged truth. Your job doesn't disappear, it
@@ -102,8 +121,13 @@ babysitter. Treat recurring corrections as a signal to update memory, not to re-
 - **Lint-only verification** — green lint, broken code. Run the actual thing.
 - **No budget ceiling** — an unattended loop with no max burns the whole budget on a
   stuck problem. Always cap iterations; consider bailing after N identical failures.
-- **A flaky gate** — a nondeterministic test makes the loop thrash forever. Stabilize
-  the check before you loop on it.
+- **A flaky gate** — a nondeterministic check makes the loop thrash, and worse, tempts
+  it to "fix" the *symptom* of a flake instead of a bug. Stabilize it *first*: measure
+  the flake rate (run the gate N times), then separate an **infra flake** (parallel
+  test-DB races, ports, shared state, test ordering) from a **real bug**. To pin the
+  cause, add a state-guard — snapshot the global before/after each test to catch the
+  mutator — or bisect; a flake that fails on a *different* test each run is usually one
+  shared-state root cause, not many.
 - **Verifying with the context that wrote the code** — a fresh check (a separate run,
   a Stop hook, a real command) catches what the author missed.
 
@@ -121,10 +145,11 @@ case, build a **loop chain** instead of a single loop:
 2. **Show the plan and get approval** before building anything.
 3. **Build it** — write `chain.json` and instantiate the backbone from the
    template library with `scripts/scaffold-loop.sh`.
-4. **Run it** — `scripts/run-chain.sh <workspace>` drives the chain: linear stages
-   self-verify, fan-out stages run their sub-loops in parallel and join, and the
-   terminal stage pauses for your sign-off. Resumable; start mid-chain with
-   `--from <stage>`.
+4. **Run it** — `scripts/run-chain.sh <workspace>` drives the chain (one loop at a
+   time via `scripts/loop-engine.sh`, whose gate can be **script** | **judge** |
+   **human**): linear stages self-verify, fan-out stages run their sub-loops in
+   parallel and join, and the terminal stage pauses for your sign-off. Resumable;
+   start mid-chain with `--from <stage>`.
 
 Each loop lives in its own folder with its own files and is reusable; loops share
 data only through `state/`. **Read `references/chains.md` for the schemas, runtime,

--- a/skill/agent-loop/scripts/verify-loop.sh
+++ b/skill/agent-loop/scripts/verify-loop.sh
@@ -3,10 +3,15 @@
 #
 # Runs the VERIFY command; if it passes, exits. Otherwise feeds the failure back
 # into a resumed Claude session and tries again, until the gate passes, a budget
-# ceiling is hit, or the loop stalls (N identical failures in a row).
+# ceiling is hit, or the loop stalls (no progress — same failure SIGNATURE in a row).
 #
 # The verify command's EXIT CODE is the gate: 0 = done. That brake is the whole
 # point — it lets reality, not the model's self-assessment, decide when to stop.
+#
+# RED-FIRST: a gate proves only what it ASSERTS, so by default the loop runs the
+# gate once before touching anything and refuses to start if it is already green
+# (a green-before-any-change gate usually is not testing the goal — the "100%-green
+# but wrong" trap). Pass --allow-green-start to skip that guard.
 #
 # Usage:
 #   verify-loop.sh --goal "<prompt>" --verify "<shell cmd>" [options]
@@ -16,22 +21,36 @@
 #   --verify   CMD      Shell command whose exit 0 means success (required).
 #   --max      N        Max iterations (default 10). The unattended-safety ceiling.
 #   --tools    LIST     --allowedTools for claude (default "Read,Edit,Bash").
-#   --stall    N        Bail after N identical verify outputs in a row (default 3).
+#   --stall    N        Bail after N no-progress rounds (same failure signature) (default 3).
+#   --reset-every N     Drop the session every N iterations for fresh eyes (default 0 = never).
+#   --model    NAME     --model for claude (default: claude's default).
+#   --escalate-model M  Switch to model M for the last try before a stall bail.
+#   --worktree PATH     Create + run inside a git worktree at PATH (isolation).
+#   --log      DIR      Write each iteration's verify output + git diff to DIR.
+#   --allow-green-start Skip the red-first guard (loop even if the gate starts green).
 #   --dry-run           Print what would run without calling claude.
 #
-# Requires: claude, jq.
+# Exit: 0 done · 1 ceiling/stall · 2 bad args · 3 gate green before any change.
+# Requires: claude, jq (git too if --worktree/--log diff).
 set -euo pipefail
 
 GOAL="" VERIFY="" MAX=10 TOOLS="Read,Edit,Bash" STALL=3 DRY=0
+RESET_EVERY=0 MODEL="" ESCALATE_MODEL="" WORKTREE="" LOGDIR="" ALLOW_GREEN=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --goal)   GOAL="$2"; shift 2 ;;
+    --goal) GOAL="$2"; shift 2 ;;
     --verify) VERIFY="$2"; shift 2 ;;
-    --max)    MAX="$2"; shift 2 ;;
-    --tools)  TOOLS="$2"; shift 2 ;;
-    --stall)  STALL="$2"; shift 2 ;;
+    --max) MAX="$2"; shift 2 ;;
+    --tools) TOOLS="$2"; shift 2 ;;
+    --stall) STALL="$2"; shift 2 ;;
+    --reset-every) RESET_EVERY="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --escalate-model) ESCALATE_MODEL="$2"; shift 2 ;;
+    --worktree) WORKTREE="$2"; shift 2 ;;
+    --log) LOGDIR="$2"; shift 2 ;;
+    --allow-green-start) ALLOW_GREEN=1; shift ;;
     --dry-run) DRY=1; shift ;;
-    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,33p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -41,60 +60,93 @@ done
 command -v claude >/dev/null || { echo "error: claude CLI not found" >&2; exit 2; }
 command -v jq     >/dev/null || { echo "error: jq not found"         >&2; exit 2; }
 
-session=""
-iter=0
-last_hash=""
-stall_count=0
+# Optional git-worktree isolation: run the whole loop on a throwaway branch so the
+# agent's edits never touch the main checkout. The worktree is left in place for
+# inspection — remove it with `git worktree remove` when done.
+if [ -n "$WORKTREE" ]; then
+  command -v git >/dev/null || { echo "error: git needed for --worktree" >&2; exit 2; }
+  branch="agent-loop-$(basename "$WORKTREE")"
+  git worktree add -q -B "$branch" "$WORKTREE" 2>/dev/null || git worktree add -q "$WORKTREE"
+  cd "$WORKTREE"; echo "↳ worktree: $WORKTREE (branch $branch)"
+fi
+[ -n "$LOGDIR" ] && mkdir -p "$LOGDIR"
 
+GATE_OUT=""
+run_gate() {  # sets GATE_OUT; returns the gate's exit code
+  set +e; GATE_OUT="$(eval "$VERIFY" 2>&1)"; local rc=$?; set -e; return $rc
+}
+
+# A failure SIGNATURE = the set of failure-ish lines with volatile noise removed
+# (paths, clock times, durations, line numbers, hex). This is what makes stall
+# detection robust: a loop that fails on a DIFFERENT line/test/timestamp each
+# round but makes no real progress still produces a STABLE signature, so we catch
+# it instead of burning the whole budget on exact-output comparison.
+signature() {
+  local norm sig
+  norm="$(printf '%s' "$1" | sed -E \
+    -e 's#/[A-Za-z0-9._/-]+#/PATH#g' -e 's/[0-9]{2}:[0-9]{2}:[0-9]{2}//g' \
+    -e 's/[0-9]+\.[0-9]+s?//g' -e 's/:[0-9]+:/:N:/g' -e 's/0x[0-9a-fA-F]+/0xADDR/g')"
+  sig="$(printf '%s\n' "$norm" | grep -iE 'fail|error|assert|traceback|exception|✗' | sort -u)"
+  [ -n "$sig" ] && printf '%s' "$sig" || printf '%s' "$norm"
+}
+
+log_iter() {  # $1 = iteration number
+  [ -n "$LOGDIR" ] || return 0
+  printf '%s\n' "$GATE_OUT" > "$LOGDIR/iter-$1.verify"
+  git diff > "$LOGDIR/iter-$1.diff" 2>/dev/null || true
+}
+
+# Red-first guard: prove the gate is actually red before looping on it.
+if run_gate; then
+  [ "$ALLOW_GREEN" -eq 1 ] && { echo "✓ verify already green (--allow-green-start). Nothing to do."; exit 0; }
+  {
+    echo "⚠ verify passed BEFORE any change — the gate may not test the goal"
+    echo "  (the '100%-green-but-wrong' trap). Make it fail on the bug first, or"
+    echo "  pass --allow-green-start if a green start is genuinely expected."
+  } >&2
+  exit 3
+fi
+
+session="" iter=0 last_sig="__init__" stall_count=0
 while [ "$iter" -lt "$MAX" ]; do
   iter=$((iter + 1))
-  echo "── iteration $iter/$MAX ── verifying: $VERIFY"
 
-  # The gate. Capture output and exit code without tripping `set -e`.
-  set +e
-  out="$(eval "$VERIFY" 2>&1)"
-  rc=$?
-  set -e
-
-  if [ "$rc" -eq 0 ]; then
-    echo "✓ verify passed on iteration $iter. Done."
-    exit 0
-  fi
-
-  # Stall detection: identical failure output N times in a row means the loop is
-  # stuck and will only burn budget. Bail so a human can look.
-  this_hash="$(printf '%s' "$out" | cksum | awk '{print $1}')"
-  if [ "$this_hash" = "$last_hash" ]; then
-    stall_count=$((stall_count + 1))
-  else
-    stall_count=0
-  fi
-  last_hash="$this_hash"
+  # Stall = no progress: same failure signature as the previous round.
+  this_sig="$(signature "$GATE_OUT")"
+  if [ "$this_sig" = "$last_sig" ]; then stall_count=$((stall_count + 1)); else stall_count=0; fi
+  last_sig="$this_sig"
   if [ "$stall_count" -ge "$STALL" ]; then
-    echo "✗ stalled: $STALL identical failures in a row. Stopping for human review." >&2
+    echo "✗ stalled: $STALL no-progress rounds (same failure signature). Stopping for human review." >&2
     exit 1
   fi
 
-  if [ "$DRY" -eq 1 ]; then
-    echo "[dry-run] would prompt claude with the goal + this failure output."
-    continue
-  fi
+  echo "── iteration $iter/$MAX ── fixing (stall $stall_count/$STALL)"
+  [ "$DRY" -eq 1 ] && { echo "[dry-run] would prompt claude with the goal + the failure."; exit 0; }
+
+  # Fresh eyes: drop the session every N iterations so the agent can abandon an
+  # entrenched failing approach instead of iterating variations of it.
+  [ "$RESET_EVERY" -gt 0 ] && [ $((iter % RESET_EVERY)) -eq 0 ] && session=""
+  # Last-ditch: escalate to a stronger model on the round before a stall bail.
+  use_model="$MODEL"
+  [ -n "$ESCALATE_MODEL" ] && [ "$stall_count" -ge $((STALL - 1)) ] && use_model="$ESCALATE_MODEL"
+  mflag=(); [ -n "$use_model" ] && mflag=(--model "$use_model")
 
   prompt="Goal: $GOAL
 
-The verification command \`$VERIFY\` is still failing. Fix the ROOT CAUSE — do not
+The verification command \`$VERIFY\` is failing. Fix the ROOT CAUSE — do not
 weaken, skip, or delete the check to make it pass. Failure output:
-$out"
+$GATE_OUT"
 
   if [ -z "$session" ]; then
-    session="$(claude -p "$prompt" \
-      --allowedTools "$TOOLS" \
-      --output-format json | jq -r '.session_id')"
+    session="$(claude -p "$prompt" "${mflag[@]}" --allowedTools "$TOOLS" --output-format json | jq -r '.session_id')"
     [ -n "$session" ] && [ "$session" != "null" ] || { echo "error: no session_id from claude" >&2; exit 1; }
   else
-    # --resume keeps the agent's prior reasoning across iterations.
-    claude -p "$prompt" --allowedTools "$TOOLS" --resume "$session" >/dev/null
+    claude -p "$prompt" "${mflag[@]}" --allowedTools "$TOOLS" --resume "$session" >/dev/null
   fi
+
+  # Re-run the gate to test this iteration's fix.
+  if run_gate; then log_iter "$iter"; echo "✓ verify passed on iteration $iter. Done."; exit 0; fi
+  log_iter "$iter"
 done
 
 echo "✗ hit iteration ceiling ($MAX) without passing verification." >&2


### PR DESCRIPTION
Hardening of the single-loop gate, learned from running a real flaky-suite loop.

**verify-loop.sh**
- **Red-first guard**: runs the gate before any change and refuses a green start (catches gates green for the wrong reason — the 100%-coverage-but-wrong trap). `--allow-green-start` opts out (exit 3).
- **Signature-based stall**: compares a *normalized failure signature* (paths/times/durations/line-numbers/hex stripped, deduped) instead of an exact-output hash — catches "no progress" even when the failure looks different each round.
- New flags: `--reset-every` (fresh-eyes session reset), `--escalate-model` (last-ditch stronger model before a stall bail), `--worktree` (throwaway branch), `--log` (per-iteration verify output + diff).

**SKILL.md**: gate-*validity* guidance (prove red-first; behavioral/live-data gates for correctness/security); flaky-gate diagnosis playbook; surfaced `judge-loop.sh` + `loop-engine.sh`.

Verified: `bash -n` + shellcheck clean, smoke-tested (red-first, dry-run, green-start). CHANGELOG + version 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Red-first verification guard with optional escape hatch to catch issues early
  * Git worktree isolation option for safer independent execution  
  * New operational controls: reset intervals, model escalation, logging capabilities

* **Documentation**
  * Version 0.2.0 release documentation and changelog
  * Updated verification gate validity guidance and diagnostic playbook
  * Safety flags and best practices for loop execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->