### PR TITLE
feat(agent-loop): v0.3.0 — compound script+judge gates

### DIFF
--- a/skill/agent-loop/CHANGELOG.md
+++ b/skill/agent-loop/CHANGELOG.md
@@ -11,6 +11,26 @@ tweak that changes nothing about the interface.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-06-18
+
+Compound gates — a script gate alone can't catch what tests don't assert. Learned
+from a loop whose tests passed but billed the wrong API key on an un-tested path; an
+independent review caught it after the loop, not during.
+
+### Added
+- `scripts/judge-check.sh`: a ONE-SHOT independent-judge GATE (vs `judge-loop.sh`'s
+  loop). A separate Claude adversarially reviews the working tree + `git diff` against
+  a rubric → exit 0 PASS / 1 FAIL with feedback. Designed to chain in a stage's
+  `verify.sh` after the objective tests: `run-tests && judge-check.sh --rubric rubric.md`.
+- Compound script+judge gating in the `transform` + `per-item` templates: `verify.sh`
+  now runs `judge-check.sh` automatically iff the stage carries a `rubric.md`, so a
+  non-trivial / correctness-critical stage becomes script AND judge just by adding a
+  rubric. `scaffold-loop.sh` substitutes `{{SCRIPTS}}` (the skill scripts dir) so the
+  scaffolded gate can call the shared judge by path.
+- SKILL.md gate-validity: "when tests can't see the bug, put a judge in the gate" —
+  the judge catches missed call-sites, scope/permission leaks, and self-weakened tests
+  that a script gate structurally cannot; it must be a separate run from the author.
+
 ## [0.2.0] — 2026-06-17
 
 Hardening of the single-loop gate, learned from running a real flaky-suite loop.

--- a/skill/agent-loop/SKILL.md
+++ b/skill/agent-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-loop
-version: 0.2.0
+version: 0.3.0
 description: Run a disciplined, verification-gated autonomous loop on the current project — Boris Cherny's "I write loops" methodology made runnable. Use whenever the user wants Claude to keep working on its own until a goal holds: "run a loop", "loop until the tests pass", "keep going until the build is green", "fix all of these until the suite is clean", "babysit this until it's done", "run this autonomously", "set up a self-verifying loop", "iterate until X", or references agent loops / loop engineering / Cherny's methodology. Trigger even when the user never says the word "loop" — any "keep doing X until condition Y holds, then stop" request is a loop. This skill picks the right primitive (/goal, a `claude -p` while-loop, a Stop hook, or a scheduled /loop), sets a budget ceiling, isolates parallel work in git worktrees, and keeps the human in the judgment seat. It also DECOMPOSES a large objective into a chain of smaller loops when one loop isn't enough — fires on "create user manuals", "break this objective into steps", "turn this into a pipeline of loops", or any multi-stage deliverable whose stages fan out over many items (one loop per page, screen, or endpoint).
 argument-hint: [goal, e.g. "all tests in api/ pass and lint is clean"]
 ---
@@ -34,6 +34,19 @@ both: **prove it red-first** — run the gate on the *unfixed* code and confirm 
 refuses a green start unless `--allow-green-start`); and for correctness- or
 security-critical goals make the gate **behavioral / live-data** (drive the real
 endpoint, assert the real contract), not coverage.
+
+**When tests can't see the bug, put a judge in the gate.** Even a behavioral,
+red-first test only checks what it asserts — it can't catch a requirement wired in one
+place but missed at another call-site, a scope/permission leak, or a loop that quietly
+weakened its own tests. For non-trivial or correctness-/security-critical stages, make
+the gate **script AND judge**: the objective tests PLUS an independent reviewer
+(`scripts/judge-check.sh`) that adversarially reads the diff against a rubric and fails
+with feedback the loop then acts on. Drop a `rubric.md` into the stage folder and the
+scaffolded `verify.sh` runs it automatically (`run-tests && judge-check.sh --rubric
+rubric.md`); the judge only fires once the tests pass, so it costs ~one model call per
+green attempt. It MUST be a separate run from the one that wrote the code — the author
+judges its own work poorly. (Real case: a loop's tests passed but it billed the wrong
+API key on one un-tested code path; only an independent review caught it.)
 
 ## Before you loop — the 60-second setup
 
@@ -140,8 +153,9 @@ case, build a **loop chain** instead of a single loop:
 1. **Plan it** — restate the objective, then run an ultracode/Workflow pass to
    decide the ordered stages, each with a goal, a verification gate, declared
    inputs/outputs, and a `next`. Mark stages that fan out (one sub-loop per page /
-   screen / endpoint). The planner fixes the stage skeleton; fan-out counts are
-   discovered at runtime.
+   screen / endpoint), and mark non-trivial / correctness-critical stages to get a
+   `rubric.md` (a compound script+judge gate — see "put a judge in the gate" above).
+   The planner fixes the stage skeleton; fan-out counts are discovered at runtime.
 2. **Show the plan and get approval** before building anything.
 3. **Build it** — write `chain.json` and instantiate the backbone from the
    template library with `scripts/scaffold-loop.sh`.

--- a/skill/agent-loop/scripts/judge-check.sh
+++ b/skill/agent-loop/scripts/judge-check.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# judge-check.sh --rubric <file> [--context "<text>"] [--tools LIST]
+#
+# A ONE-SHOT independent-judge GATE (not a loop). A SEPARATE Claude — not the one
+# that wrote the code — adversarially reviews the current working tree + `git diff`
+# against the rubric and exits 0 = PASS, 1 = FAIL (printing what must change).
+#
+# Chain it in a stage's verify.sh AFTER the objective tests so the gate is
+# script AND judge:
+#     run-tests && judge-check.sh --rubric "$LOOP_DIR/rubric.md"
+#
+# Why: tests assert only what they assert. The judge catches what they
+# structurally can't — a missed call-site, a scope/permission leak, a loop that
+# weakened its own tests to pass. The author is a poor judge of its own work, so
+# this MUST be a separate run from the one that produced the change.
+#
+# On FAIL the feedback is printed (captured by the loop) so the next iteration can
+# act on it. The judge only runs once the tests pass (the `&&`), so it costs ~one
+# model call per green attempt, not one per loop iteration.
+#
+# Experimental: needs claude + jq. Prefer adding it to correctness-/security-
+# critical stages; a trivial mechanical stage may not need a judge.
+set -euo pipefail
+
+RUBRIC="" CONTEXT="" TOOLS="Read,Bash"
+while [ $# -gt 0 ]; do case "$1" in
+  --rubric) RUBRIC="$2"; shift 2 ;;
+  --context) CONTEXT="$2"; shift 2 ;;
+  --tools) TOOLS="$2"; shift 2 ;;
+  -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+  *) echo "unknown arg: $1" >&2; exit 2 ;;
+esac; done
+[ -f "$RUBRIC" ] || { echo "judge-check: need an existing --rubric file" >&2; exit 2; }
+command -v claude >/dev/null && command -v jq >/dev/null || { echo "judge-check: need claude + jq" >&2; exit 2; }
+
+prompt="You are a strict, INDEPENDENT reviewer — you did NOT write this code. Adversarially
+inspect the CURRENT working tree: read the changed files and run \`git diff\` (and
+\`git diff --staged\`). Decide whether the change satisfies EVERY item in the rubric.
+Be skeptical and look specifically for: a requirement wired in one place but MISSED at
+another call-site; scope/permission/tenant leaks; and tests that were deleted, weakened,
+or that don't exercise the real path (e.g. mocking the very thing under test). When in
+doubt, FAIL. Respond with ONLY JSON: {\"pass\":true|false,\"feedback\":\"specific, with file:line, what must change\"}.
+${CONTEXT:+
+CONTEXT: $CONTEXT}
+
+RUBRIC:
+$(cat "$RUBRIC")"
+
+verdict="$(claude -p "$prompt" --allowedTools "$TOOLS" --output-format json | jq -r '.result')"
+pass="$(printf '%s' "$verdict" | jq -r '.pass' 2>/dev/null || echo false)"
+feedback="$(printf '%s' "$verdict" | jq -r '.feedback' 2>/dev/null || echo 'judge returned no parseable verdict')"
+
+if [ "$pass" = "true" ]; then
+  echo "✓ judge: PASS"
+  exit 0
+fi
+echo "✗ judge: FAIL — $feedback" >&2
+exit 1

--- a/skill/agent-loop/scripts/scaffold-loop.sh
+++ b/skill/agent-loop/scripts/scaffold-loop.sh
@@ -30,6 +30,11 @@ for kv in ${SETS[@]+"${SETS[@]}"}; do
     | xargs -0 -r sed -i "s|{{$k}}|$ev|g"
 done
 
+# Always expose the skill's scripts dir so a stage's verify.sh can call shared gates
+# (e.g. judge-check.sh for a compound script+judge gate) by absolute path.
+find "$DEST" -type f \( -name '*.json' -o -name '*.md' -o -name '*.sh' \) -print0 \
+  | xargs -0 -r sed -i "s|{{SCRIPTS}}|$(esc "$HERE")|g"
+
 # self-chaining entrypoint: run this loop, then (on success) the next one
 printf '#!/usr/bin/env bash\nexec %q "$(cd "$(dirname "$0")" && pwd)" "$@"\n' "$HERE/loop-engine.sh" > "$DEST/run.sh"
 chmod +x "$DEST/run.sh"

--- a/skill/agent-loop/templates/per-item/verify.sh
+++ b/skill/agent-loop/templates/per-item/verify.sh
@@ -5,3 +5,10 @@ mapfile -t outs < <(jq -r '.outputs[]? // empty' "$LOOP_DIR/loop.json")
 [ "${#outs[@]}" -gt 0 ] || { echo "no outputs declared"; exit 1; }
 for o in "${outs[@]}"; do [ -s "$WORKSPACE/$o" ] || { echo "missing/empty output: $o"; exit 1; }; done
 echo "ok: ${#outs[@]} output(s) present"
+# Compound gate: if this stage carries a rubric.md, an INDEPENDENT judge must ALSO
+# pass (script AND judge). Add a rubric.md to non-trivial / correctness-critical
+# stages — tests assert only what they assert; the judge catches missed call-sites,
+# scope leaks, and self-weakened tests.
+if [ -f "$LOOP_DIR/rubric.md" ]; then
+  bash "{{SCRIPTS}}/judge-check.sh" --rubric "$LOOP_DIR/rubric.md"
+fi

--- a/skill/agent-loop/templates/transform/verify.sh
+++ b/skill/agent-loop/templates/transform/verify.sh
@@ -5,3 +5,10 @@ mapfile -t outs < <(jq -r '.outputs[]? // empty' "$LOOP_DIR/loop.json")
 [ "${#outs[@]}" -gt 0 ] || { echo "no outputs declared"; exit 1; }
 for o in "${outs[@]}"; do [ -s "$WORKSPACE/$o" ] || { echo "missing/empty output: $o"; exit 1; }; done
 echo "ok: ${#outs[@]} output(s) present"
+# Compound gate: if this stage carries a rubric.md, an INDEPENDENT judge must ALSO
+# pass (script AND judge). Add a rubric.md to non-trivial / correctness-critical
+# stages — tests assert only what they assert; the judge catches missed call-sites,
+# scope leaks, and self-weakened tests.
+if [ -f "$LOOP_DIR/rubric.md" ]; then
+  bash "{{SCRIPTS}}/judge-check.sh" --rubric "$LOOP_DIR/rubric.md"
+fi


### PR DESCRIPTION
Adds an independent-judge GATE so a stage gate can be **script AND judge**, not tests-only. Motivated by a real miss: a loop's tests passed but it billed the wrong API key on an un-tested path — only an independent review caught it.

- `judge-check.sh`: one-shot judge gate (separate Claude reviews diff vs rubric → pass/fail+feedback).
- `transform`/`per-item` templates auto-run it iff the stage has a `rubric.md`; `scaffold-loop.sh` substitutes `{{SCRIPTS}}`.
- SKILL.md gate-validity + planner cue. Verified: bash -n + shellcheck clean, scaffold-substitution smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent judge gate for automated stage verification based on custom rubric criteria.
  * Automatic compound verification combining objective tests with judge assessment when rubric.md files exist.

* **Documentation**
  * Updated verification best practices recommending judge-based assessment for security and correctness-critical pipeline stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->