### PR TITLE
feat(agent-loop): v0.4.0 — lessons from a real loop-chain run

### DIFF
--- a/skill/agent-loop/CHANGELOG.md
+++ b/skill/agent-loop/CHANGELOG.md
@@ -11,6 +11,52 @@ tweak that changes nothing about the interface.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-06-18
+
+Lessons banked from running a real 4-stage loop chain (rebuilding a product's user
+manual). The chain over-delivered on teaching us where the skill was thin.
+
+### Added
+- **Per-stage effort/model.** `verify-loop.sh` + `judge-check.sh` take `--effort`
+  (`low`…`max`); `loop-engine.sh` threads `engine.effort` / `engine.model` from
+  `loop.json` to the script-gate runner. A chain ran every stage at the default
+  effort — mechanical and judgment stages alike — with no knob to change it.
+- **Visual-judge recipe** (SKILL.md): for a *visual* deliverable, render the result
+  to a PNG in `verify.sh`, then point the rubric at the image — `judge-check.sh`'s
+  reviewer uses Read, which VIEWS images, so it rules on look-and-feel. Proven: a
+  design loop's judge viewed the rendered pages and bounced its first redesign.
+
+### Changed
+- `judge-check.sh` now **robustly recovers the verdict object** from a judge that
+  narrates or fences its JSON (was a bare `jq` parse → false-negative gate failures
+  when the judge added prose). Reads the REAL verdict; a `pass:false` still fails.
+
+### Documented (anti-patterns / gotchas)
+- **A gate the loop can edit** is the sharpest new anti-pattern — a design loop, hitting
+  the false-negative above, edited the judge script *itself*. That time a legit fix, but
+  the capability is the risk; keep gate + skill scripts out of the loop's writable scope
+  and diff them after a run.
+- **Bake project conventions (file-size cap, ruff, type-check) into stage gates** — a
+  stage with no lint gate shipped a 1121-line file.
+- **Declare a real artifact as a stage output**, not the engine's `state/.done/<id>`
+  marker (spurious "output missing" warnings otherwise).
+- **The terminal stage must be `human`** (or `--allow-green-start`) — a redundant final
+  script gate is green-before-change and trips the red-first guard (exit 3).
+
+## [0.3.1] — 2026-06-18
+
+### Fixed
+
+- `judge-check.sh` now robustly recovers the verdict object from the judge's
+  `.result`. The judge is a separate Claude run that routinely narrates and/or
+  wraps its JSON in a ```` ```json ```` fence, so `.result` was prose + JSON, not a
+  bare object — `jq -r '.result' | jq '.pass'` failed to parse and every green
+  attempt reported "judge returned no parseable verdict" regardless of the real
+  verdict. A small `python3` extractor scans for fenced/balanced/greedy JSON
+  candidates and picks the last that validates as an object with a `pass` key.
+  The gate is unchanged: a `pass:false` verdict still FAILS, and truly empty
+  output still reports "no parseable verdict". Adds a `python3` dependency.
+
 ## [0.3.0] — 2026-06-18
 
 Compound gates — a script gate alone can't catch what tests don't assert. Learned

--- a/skill/agent-loop/SKILL.md
+++ b/skill/agent-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-loop
-version: 0.3.0
+version: 0.4.0
 description: Run a disciplined, verification-gated autonomous loop on the current project — Boris Cherny's "I write loops" methodology made runnable. Use whenever the user wants Claude to keep working on its own until a goal holds: "run a loop", "loop until the tests pass", "keep going until the build is green", "fix all of these until the suite is clean", "babysit this until it's done", "run this autonomously", "set up a self-verifying loop", "iterate until X", or references agent loops / loop engineering / Cherny's methodology. Trigger even when the user never says the word "loop" — any "keep doing X until condition Y holds, then stop" request is a loop. This skill picks the right primitive (/goal, a `claude -p` while-loop, a Stop hook, or a scheduled /loop), sets a budget ceiling, isolates parallel work in git worktrees, and keeps the human in the judgment seat. It also DECOMPOSES a large objective into a chain of smaller loops when one loop isn't enough — fires on "create user manuals", "break this objective into steps", "turn this into a pipeline of loops", or any multi-stage deliverable whose stages fan out over many items (one loop per page, screen, or endpoint).
 argument-hint: [goal, e.g. "all tests in api/ pass and lint is clean"]
 ---
@@ -47,6 +47,16 @@ rubric.md`); the judge only fires once the tests pass, so it costs ~one model ca
 green attempt. It MUST be a separate run from the one that wrote the code — the author
 judges its own work poorly. (Real case: a loop's tests passed but it billed the wrong
 API key on one un-tested code path; only an independent review caught it.)
+
+**Visual / subjective deliverables — render, then let the judge SEE it.** A judge reading
+HTML/CSS can't tell whether a page *looks* good. But `judge-check.sh`'s reviewer uses Read,
+which VIEWS images — so for a visual goal, have the gate render the result to a PNG, then
+point the rubric at that file ("view `build/page-*.png`; FAIL if it looks auto-generated").
+Proven: a manual-design loop's judge viewed the rendered pages and bounced its first
+redesign. And fold the project's OWN conventions into the gate — file-size cap, `ruff`/lint,
+type-check — because a stage with no lint gate happily ships a 1000-line file (seen for real).
+Give the judge stage a higher `effort` (per-stage `engine.effort` / `--effort`); the
+mechanical stages can stay low.
 
 ## Before you loop — the 60-second setup
 
@@ -143,6 +153,13 @@ babysitter. Treat recurring corrections as a signal to update memory, not to re-
   shared-state root cause, not many.
 - **Verifying with the context that wrote the code** — a fresh check (a separate run,
   a Stop hook, a real command) catches what the author missed.
+- **A gate the loop can edit** — if the loop has write access to its own gate (the verify
+  script, the rubric, or a skill script referenced by absolute path), it can make a red
+  gate green by *weakening the check* instead of doing the work. Keep gate + skill scripts
+  OUTSIDE the loop's writable scope (read-only, or a path its tools can't reach), and diff
+  them after a run. Seen for real: a design loop whose judge gate gave false negatives
+  edited the judge script itself — that time a legitimate fix, but the *capability* is the
+  risk, and you only know which by reviewing the diff.
 
 ## Decompose a big objective into a loop chain
 

--- a/skill/agent-loop/references/chains.md
+++ b/skill/agent-loop/references/chains.md
@@ -65,7 +65,7 @@ and only advances when **all** pass (the join).
   "gate": {"type": "script", "verify": "bash \"$LOOP_DIR/verify.sh\""},
   "inputs":  ["state/pages.json"],
   "outputs": ["state/toc.json"],
-  "engine":  {"max": 6, "tools": "Read,Write,Edit,Bash"},
+  "engine":  {"max": 6, "tools": "Read,Write,Edit,Bash", "effort": "high", "model": ""},
   "next": "03-pages"
 }
 ```
@@ -77,7 +77,18 @@ and only advances when **all** pass (the join).
   loop keeps its budget ceiling and stall detection.
 - **inputs/outputs** are the data contract. The engine refuses to start a loop
   whose declared inputs are missing, and warns if a passed loop didn't produce its
-  outputs. This is what makes loops independently runnable and resumable.
+  outputs. This is what makes loops independently runnable and resumable. Declare a
+  REAL artifact (e.g. `build/manual.html`) as the output — NOT the engine's own
+  `state/.done/<stage>` marker, or every stage logs a spurious "output missing"
+  warning (the engine owns that marker itself).
+- **engine.effort / engine.model** (optional) set per-stage reasoning effort
+  (`low`…`max`) and model; default = claude's session default. Set `effort` high on
+  the hard judgment stages (design, judge), low on mechanical ones — otherwise the
+  chain pays judgment effort for a file copy and vice-versa.
+- **The terminal stage must be `human`** (or pass `--allow-green-start`). A final
+  "review" stage whose *script* gate merely re-checks what earlier stages produced is
+  green before the loop changes anything → the red-first guard correctly refuses it
+  (exit 3). Make it a `human` sign-off, not a redundant script gate.
 
 ## Runtime
 

--- a/skill/agent-loop/scripts/judge-check.sh
+++ b/skill/agent-loop/scripts/judge-check.sh
@@ -22,16 +22,19 @@
 # critical stages; a trivial mechanical stage may not need a judge.
 set -euo pipefail
 
-RUBRIC="" CONTEXT="" TOOLS="Read,Bash"
+RUBRIC="" CONTEXT="" TOOLS="Read,Bash" EFFORT="" MODEL=""
 while [ $# -gt 0 ]; do case "$1" in
   --rubric) RUBRIC="$2"; shift 2 ;;
   --context) CONTEXT="$2"; shift 2 ;;
   --tools) TOOLS="$2"; shift 2 ;;
+  --effort) EFFORT="$2"; shift 2 ;;
+  --model) MODEL="$2"; shift 2 ;;
   -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
   *) echo "unknown arg: $1" >&2; exit 2 ;;
 esac; done
 [ -f "$RUBRIC" ] || { echo "judge-check: need an existing --rubric file" >&2; exit 2; }
-command -v claude >/dev/null && command -v jq >/dev/null || { echo "judge-check: need claude + jq" >&2; exit 2; }
+command -v claude >/dev/null && command -v jq >/dev/null && command -v python3 >/dev/null \
+  || { echo "judge-check: need claude + jq + python3" >&2; exit 2; }
 
 prompt="You are a strict, INDEPENDENT reviewer — you did NOT write this code. Adversarially
 inspect the CURRENT working tree: read the changed files and run \`git diff\` (and
@@ -46,7 +49,42 @@ CONTEXT: $CONTEXT}
 RUBRIC:
 $(cat "$RUBRIC")"
 
-verdict="$(claude -p "$prompt" --allowedTools "$TOOLS" --output-format json | jq -r '.result')"
+eflag=(); [ -n "$EFFORT" ] && eflag=(--effort "$EFFORT")
+mflag=(); [ -n "$MODEL" ] && mflag=(--model "$MODEL")
+raw="$(claude -p "$prompt" "${eflag[@]}" "${mflag[@]}" --allowedTools "$TOOLS" --output-format json | jq -r '.result')"
+
+# The judge is a separate Claude run; it routinely narrates and/or wraps its
+# verdict in a ```json fence, so .result is prose + JSON, not a bare object.
+# Recover the verdict object (validating each candidate with json.loads) before
+# reading it. This reads the judge's REAL decision — a pass:false verdict still
+# FAILS the gate — it does not weaken the check.
+verdict="$(printf '%s' "$raw" | python3 -c '
+import json, re, sys
+text = sys.stdin.read()
+cands = []
+for m in re.finditer(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.S):
+    cands.append(m.group(1))
+depth = 0; start = None
+for i, ch in enumerate(text):
+    if ch == "{":
+        if depth == 0: start = i
+        depth += 1
+    elif ch == "}" and depth > 0:
+        depth -= 1
+        if depth == 0 and start is not None:
+            cands.append(text[start:i + 1]); start = None
+a = text.find("{"); b = text.rfind("}")
+if a != -1 and b > a: cands.append(text[a:b + 1])
+best = None
+for c in cands:
+    try:
+        obj = json.loads(c)
+    except Exception:
+        continue
+    if isinstance(obj, dict) and "pass" in obj:
+        best = obj
+sys.stdout.write(json.dumps(best) if best is not None else "")
+')"
 pass="$(printf '%s' "$verdict" | jq -r '.pass' 2>/dev/null || echo false)"
 feedback="$(printf '%s' "$verdict" | jq -r '.feedback' 2>/dev/null || echo 'judge returned no parseable verdict')"
 

--- a/skill/agent-loop/scripts/loop-engine.sh
+++ b/skill/agent-loop/scripts/loop-engine.sh
@@ -43,10 +43,15 @@ else
 
   goal="$(cat "$LOOP_DIR/$(j '.goal_file // "prompt.md"')" 2>/dev/null || j '.goal // ""')"
   max="$(j '.engine.max // 8')"; tools="$(j '.engine.tools // "Read,Edit,Bash"')"
+  # Per-stage reasoning effort / model (default = claude's session default): set
+  # engine.effort high on the hard judgment stages, low on mechanical ones.
+  effort="$(j '.engine.effort // ""')"; model="$(j '.engine.model // ""')"
+  eopt=(); [ -n "$effort" ] && eopt=(--effort "$effort")
+  mopt=(); [ -n "$model" ] && mopt=(--model "$model")
   cd "$WORKSPACE"
   case "$gate" in
     script)
-      "$HERE/verify-loop.sh" --goal "$goal" --verify "$(j '.gate.verify')" --max "$max" --tools "$tools"
+      "$HERE/verify-loop.sh" --goal "$goal" --verify "$(j '.gate.verify')" --max "$max" --tools "$tools" "${eopt[@]}" "${mopt[@]}"
       ;;
     judge)
       "$HERE/judge-loop.sh" --goal "$goal" --rubric "$LOOP_DIR/$(j '.gate.rubric // "rubric.md"')" --max "$max" --tools "$tools"

--- a/skill/agent-loop/scripts/verify-loop.sh
+++ b/skill/agent-loop/scripts/verify-loop.sh
@@ -35,7 +35,7 @@
 set -euo pipefail
 
 GOAL="" VERIFY="" MAX=10 TOOLS="Read,Edit,Bash" STALL=3 DRY=0
-RESET_EVERY=0 MODEL="" ESCALATE_MODEL="" WORKTREE="" LOGDIR="" ALLOW_GREEN=0
+RESET_EVERY=0 MODEL="" EFFORT="" ESCALATE_MODEL="" WORKTREE="" LOGDIR="" ALLOW_GREEN=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --goal) GOAL="$2"; shift 2 ;;
@@ -45,6 +45,7 @@ while [ $# -gt 0 ]; do
     --stall) STALL="$2"; shift 2 ;;
     --reset-every) RESET_EVERY="$2"; shift 2 ;;
     --model) MODEL="$2"; shift 2 ;;
+    --effort) EFFORT="$2"; shift 2 ;;
     --escalate-model) ESCALATE_MODEL="$2"; shift 2 ;;
     --worktree) WORKTREE="$2"; shift 2 ;;
     --log) LOGDIR="$2"; shift 2 ;;
@@ -130,6 +131,7 @@ while [ "$iter" -lt "$MAX" ]; do
   use_model="$MODEL"
   [ -n "$ESCALATE_MODEL" ] && [ "$stall_count" -ge $((STALL - 1)) ] && use_model="$ESCALATE_MODEL"
   mflag=(); [ -n "$use_model" ] && mflag=(--model "$use_model")
+  eflag=(); [ -n "$EFFORT" ] && eflag=(--effort "$EFFORT")
 
   prompt="Goal: $GOAL
 
@@ -138,10 +140,10 @@ weaken, skip, or delete the check to make it pass. Failure output:
 $GATE_OUT"
 
   if [ -z "$session" ]; then
-    session="$(claude -p "$prompt" "${mflag[@]}" --allowedTools "$TOOLS" --output-format json | jq -r '.session_id')"
+    session="$(claude -p "$prompt" "${mflag[@]}" "${eflag[@]}" --allowedTools "$TOOLS" --output-format json | jq -r '.session_id')"
     [ -n "$session" ] && [ "$session" != "null" ] || { echo "error: no session_id from claude" >&2; exit 1; }
   else
-    claude -p "$prompt" "${mflag[@]}" --allowedTools "$TOOLS" --resume "$session" >/dev/null
+    claude -p "$prompt" "${mflag[@]}" "${eflag[@]}" --allowedTools "$TOOLS" --resume "$session" >/dev/null
   fi
 
   # Re-run the gate to test this iteration's fix.


### PR DESCRIPTION
Five lessons banked from running a real 4-stage chain (rebuilding a user manual end-to-end):

- **Per-stage effort/model** — `--effort` on `verify-loop.sh`/`judge-check.sh`; `loop-engine.sh` threads `engine.effort`/`model`.
- **`judge-check.sh` robust verdict recovery** — handles a judge that narrates/fences its JSON (was false-negative). The design loop wrote this fix itself when its gate misfired; verified legit and kept.
- **New anti-pattern: a gate the loop can edit** — keep gate + skill scripts out of the loop's writable scope.
- **Visual-judge recipe** — render to PNG, point the rubric at the image (the judge VIEWS it). Proven on the design stage.
- **Conventions in gates** (a stage with no lint gate shipped a 1121-line file); real-artifact outputs; terminal stage = human.

Verified: bash -n + shellcheck clean; `--effort`/`--model` parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes — Version 0.4.0

* **New Features**
  * Configure reasoning effort and model selection per loop stage for fine-grained control
  * Visual judge recipe: render outputs to PNG and evaluate via rubric-based assessment
  * Robust verdict recovery from judge output containing prose or wrapped JSON

* **Documentation**
  * New operational gotchas and anti-pattern guidance for agent-loop setup
  * Enhanced guidance for verifying visual and subjective deliverables
  * Updated configuration examples with engine parameter documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->